### PR TITLE
Add va_args-support to ASSERT and CHECK

### DIFF
--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -5,7 +5,7 @@
 #include <cstdarg>
 
 void _smek_error_log(const char *file, u32 line, const char *message, ...) {
-    std::fprintf(stderr, RED "!%s" RESET "|" BLUE "%d" RESET ": ", file, line);
+    std::fprintf(stderr, RED "! %s" RESET "|" BLUE "%d" RESET ": ", file, line);
     va_list args;
     va_start(args, message);
     std::vfprintf(stderr, message, args);
@@ -14,7 +14,7 @@ void _smek_error_log(const char *file, u32 line, const char *message, ...) {
 }
 
 void _smek_warn_log(const char *file, u32 line, const char *message, ...) {
-    std::fprintf(stderr, YELLOW "?%s" RESET "|" BLUE "%d" RESET ": ", file, line);
+    std::fprintf(stderr, YELLOW "? %s" RESET "|" BLUE "%d" RESET ": ", file, line);
     va_list args;
     va_start(args, message);
     std::vfprintf(stderr, message, args);
@@ -39,20 +39,28 @@ void _smek_unreachable(const char *file, u32 line) {
     std::exit('U'); // U for Unreachable
 }
 
-void _smek_assert(const char *file, u32 line, bool passed, const char *msg, const char *expr) {
+void _smek_assert(const char *file, u32 line, bool passed, const char *expr, const char *msg, ...) {
     if (passed) return;
 
     std::fprintf(stderr, RED "%s" RESET "|" RED "%d" RESET ": ASSERT(%s)\n", file, line, expr);
-    std::fprintf(stderr, BOLDRED "| " RESET "%s\n", msg);
-    std::fprintf(stderr, BOLDRED "| " RESET "End of Transmission\n");
+    std::fprintf(stderr, BOLDRED "| " RESET);
+    va_list args;
+    va_start(args, msg);
+    std::vfprintf(stderr, msg, args);
+    va_end(args);
+    std::fprintf(stderr, "\n" BOLDRED "| " RESET "End of Transmission\n");
 
     std::exit('A'); // A for Assert
 }
 
-bool _smek_check(const char *file, u32 line, bool passed, const char *msg, const char *expr) {
+bool _smek_check(const char *file, u32 line, bool passed, const char *expr, const char *msg, ...) {
     if (!passed) {
         std::fprintf(stderr, YELLOW "%s" RESET "|" BLUE "%d" RESET ": %s\n", file, line, expr);
-        std::fprintf(stderr, YELLOW "| " RESET "%s\n", msg);
+        std::fprintf(stderr, YELLOW "| " RESET);
+        va_list args;
+        va_start(args, msg);
+        std::vfprintf(stderr, msg, args);
+        va_end(args);
     }
     return passed;
 }

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -13,8 +13,12 @@ void _smek_info_log(const char *file, u32 line, const char *message, ...);
 
 #define UNREACHABLE _smek_unreachable(__FILE__, __LINE__)
 void _smek_unreachable(const char *file, u32 line);
+
+// https://stackoverflow.com/a/5891370/4904628
+// Tested with clang++ as well.
+
 #define STR(x) #x
-#define ASSERT(pass, msg) _smek_assert(__FILE__, __LINE__, pass, msg, STR(pass))
-void _smek_assert(const char *file, u32 line, bool passed, const char *msg, const char *expr);
-#define CHECK(pass, msg) _smek_check(__FILE__, __LINE__, pass, msg, STR(pass))
-bool _smek_check(const char *file, u32 line, bool passed, const char *msg, const char *expr);
+#define ASSERT(pass, msg, ...) _smek_assert(__FILE__, __LINE__, pass, STR(pass), msg, ##__VA_ARGS__)
+void _smek_assert(const char *file, u32 line, bool passed, const char *expr, const char *msg, ...);
+#define CHECK(pass, msg, ...) _smek_check(__FILE__, __LINE__, pass, STR(pass), msg, ##__VA_ARGS__)
+bool _smek_check(const char *file, u32 line, bool passed, const char *expr, const char *msg, ...);


### PR DESCRIPTION
`##__VA_ARGS__` gets expanded to nothing instead of `,` when no arguments are passed, so you're not required to pass arguments.