### PR TITLE
Print test results on stderr instead of stdout

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -55,10 +55,10 @@ unsigned int TestSuite::run() {
                     tests[i].name, tests[i].file, tests[i].line);
         }
     }
-    std::printf(CLEAR);
-    std::printf(GREEN "Passed:" RESET " %d\n", succeeded);
+    std::fprintf(stderr, CLEAR);
+    std::fprintf(stderr, GREEN "Passed:" RESET " %d\n", succeeded);
     if (succeeded != num_tests)
-        std::printf(RED "Failed:" RESET " %d\n", num_tests - succeeded);
+        std::fprintf(stderr, RED "Failed:" RESET " %d\n", num_tests - succeeded);
 
     delete[] tests;
 


### PR DESCRIPTION
When printing to both `stdout` and `stderr` directly after each other, the
output (at least on my machine) came in the wrong order.
