### PR TITLE
Fix base case for sntprint

### DIFF
--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -50,7 +50,10 @@ i32 sntprint<>(char *buffer, u32 buf_size, const char *fmt) {
     if (buf_size == 0) return 0;
     u32 head = 0;
     while (fmt[head]) {
-        if (buf_size == head) { buffer[head-1] = '\0'; return -1; }
+        if (buf_size == head) {
+            buffer[head-1] = '\0';
+            break;
+        }
         buffer[head] = fmt[head];
         head++;
     }

--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -47,6 +47,7 @@ u32 smek_snprint(char *out_buffer, u32 buf_size, const char *in_buffer) {
 
 template<>
 i32 sntprint<>(char *buffer, u32 buf_size, const char *fmt) {
+    if (buf_size == 0) return 0;
     u32 head = 0;
     while (fmt[head]) {
         if (buf_size == head) { buffer[head-1] = '\0'; return -1; }


### PR DESCRIPTION
Used to give the following warnings on CI:

```
./src/util/tprint.cpp: In function ‘void _smek_log_warn(const char*, u32, const char*, const char*, Args ...) [with Args = {char}]’:
./src/util/tprint.cpp:52:48: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   52 |         if (buf_size == head) { buffer[head-1] = '\0'; return -1; }
      |                                 ~~~~~~~~~~~~~~~^~~~~~
In file included from ./src/util/../util/util.h:8,
                 from ./src/util/tprint.h:51,
                 from ./src/util/tprint.cpp:2,
                 from <command-line>:
./src/util/../util/log.h:54:10: note: at offset 4294967295 to object ‘buffer’ with size 512 declared here
   54 |     char buffer[LOG_BUFFER_SIZE] = {};
      |          ^~~~~~
```