### PR TITLE
Ignore os.environ

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,58 +10,58 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install dependencies
-        run: |
-        python -m pip install --upgrade pip
-
-      - name: Install dependencies
-        run: |
-          pacman -Syy
-          pacman --noconfirm -S binutils gcc clang sdl2 scons glibc
-
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-
-      - name: requirements.txt
-        run: |
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install -r requirements.txt
-
-      - name: Run tests
-        run: |
-          source venv/bin/activate
-          scons -Q tests --ci --report --jumbo
-
-      - name: Upload build
-        if: ${{ !success() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: build
-          path: |
-            bin/tests/SMEK
-            bin/tests/assets*.bin
-
-      - name: Upload report
-        if: ${{ !success() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: report
-          path: |
-            bin/tests/report.txt
-
-      - name: Try to build release version (g++)
-        run: |
-          source venv/bin/activate
-          scons -Q --release --no-imgui --jumbo CXX=g++
-
-      - name: Try to build release version (clang++)
-        run: |
-          source venv/bin/activate
-          scons -Q --release --no-imgui --jumbo CXX=clang++
+    - uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
+  
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+  
+    - name: Install PIP
+      run: |
+      python -m pip install --upgrade pip
+  
+    - name: Install Pacman dependencies
+      run: |
+        pacman -Syy
+        pacman --noconfirm -S binutils gcc clang sdl2 scons glibc
+  
+    - name: requirements.txt
+      run: |
+        python3 -m venv venv
+        source venv/bin/activate
+        pip install -r requirements.txt
+  
+    - name: Run tests
+      run: |
+        source venv/bin/activate
+        scons -Q tests --ci --report --jumbo
+  
+    - name: Upload build
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: |
+          bin/tests/SMEK
+          bin/tests/assets*.bin
+  
+    - name: Upload report
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: report
+        path: |
+          bin/tests/report.txt
+  
+    - name: Try to build release version (g++)
+      run: |
+        source venv/bin/activate
+        scons -Q --release --no-imgui --jumbo CXX=g++
+  
+    - name: Try to build release version (clang++)
+      run: |
+        source venv/bin/activate
+        scons -Q --release --no-imgui --jumbo CXX=clang++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
-      - name: Set up Python 3.8
+      - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
+      - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
       - name: Install dependencies
         run: |
           pacman -Syy
-          pacman --noconfirm -S binutils gcc clang python python-pip python-wheel sdl2 scons git glibc
+          pacman --noconfirm -S binutils gcc clang sdl2 scons glibc
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python3 -m venv venv
           source venv/bin/activate
-          pip install --user -r requirements.txt
+          pip install -r requirements.txt
       - name: Run tests
         run: |
           scons -Q tests --ci --report --jumbo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Syy
-          pacman --noconfirm -S binutils gcc clang python python-pip python-wheel sdl2 scons git glibc
+          pacman --noconfirm -S binutils gcc clang python python-pip python-wheel sdl2 git glibc
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
   
     - name: Install PIP
       run: |
-      python -m pip install --upgrade pip
+        python -m pip install --upgrade pip
   
     - name: Install Pacman dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: "recursive"
   
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -26,13 +23,18 @@ jobs:
     - name: Install Pacman dependencies
       run: |
         pacman -Syy
-        pacman --noconfirm -S binutils gcc clang sdl2 scons glibc
+        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc
   
     - name: requirements.txt
       run: |
         python3 -m venv venv
         source venv/bin/activate
         pip install -r requirements.txt
+
+    # Requires git for submodules (2020)
+    - uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
   
     - name: Run tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Pacman deps
       run: |
         pacman -Syy
-        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc
+        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc libffi
         
     # Requires git for submodules (2020)
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,29 +10,35 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
-      - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
         python -m pip install --upgrade pip
+
       - name: Install dependencies
         run: |
           pacman -Syy
           pacman --noconfirm -S binutils gcc clang sdl2 scons glibc
+
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+
       - name: requirements.txt
         run: |
           python3 -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt
+
       - name: Run tests
         run: |
           source venv/bin/activate
           scons -Q tests --ci --report --jumbo
+
       - name: Upload build
         if: ${{ !success() }}
         uses: actions/upload-artifact@v2
@@ -41,6 +47,7 @@ jobs:
           path: |
             bin/tests/SMEK
             bin/tests/assets*.bin
+
       - name: Upload report
         if: ${{ !success() }}
         uses: actions/upload-artifact@v2
@@ -48,10 +55,12 @@ jobs:
           name: report
           path: |
             bin/tests/report.txt
+
       - name: Try to build release version (g++)
         run: |
           source venv/bin/activate
           scons -Q --release --no-imgui --jumbo CXX=g++
+
       - name: Try to build release version (clang++)
         run: |
           source venv/bin/activate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:
+    - name: Install Pacman deps
+      run: |
+        pacman -Syy
+        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc
+        
+    # Requires git for submodules (2020)
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
   
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -20,22 +30,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
   
-    - name: Install Pacman dependencies
-      run: |
-        pacman -Syy
-        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc
-  
     - name: requirements.txt
       run: |
         python3 -m venv venv
         source venv/bin/activate
         pip install -r requirements.txt
 
-    # Requires git for submodules (2020)
-    - uses: actions/checkout@v2
-      with:
-        submodules: "recursive"
-  
     - name: Run tests
       run: |
         source venv/bin/activate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Pacman deps
       run: |
         pacman -Syy
-        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc libffi
+        pacman --noconfirm -S binutils gcc clang sdl2 git scons glibc
         
     # Requires git for submodules (2020)
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: |
+          source venv/bin/activate
           scons -Q tests --ci --report --jumbo
       - name: Upload build
         if: ${{ !success() }}
@@ -42,7 +43,9 @@ jobs:
             bin/tests/report.txt
       - name: Try to build release version (g++)
         run: |
+          source venv/bin/activate
           scons -Q --release --no-imgui --jumbo CXX=g++
       - name: Try to build release version (clang++)
         run: |
+          source venv/bin/activate
           scons -Q --release --no-imgui --jumbo CXX=clang++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,15 @@ jobs:
       - name: Install dependencies
         run: |
           pacman -Syy
-          pacman --noconfirm -S binutils gcc clang python python-pip python-wheel sdl2 git glibc
+          pacman --noconfirm -S binutils gcc clang python python-pip python-wheel sdl2 scons git glibc
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
       - name: requirements.txt
         run: |
-          python3 -m pip install --user -r requirements.txt
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --user -r requirements.txt
       - name: Run tests
         run: |
           scons -Q tests --ci --report --jumbo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 lark-parser==0.9.0
 Pillow==7.1.2
-SCons==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lark-parser==0.9.0
 Pillow==7.1.2
+SCons==4.0.1

--- a/sconstruct.py
+++ b/sconstruct.py
@@ -7,7 +7,6 @@ from subprocess import Popen, PIPE
 from collections import defaultdict
 from itertools import chain
 
-
 DEBUG_FLAGS = ["-ggdb", "-O0", "-DDEBUG"]
 RELEASE_FLAGS = ["-O2", "-DRELEASE"]
 WARNINGS = "-Wall -Wno-unused -Wno-format-security -Wno-invalid-offsetof"
@@ -105,7 +104,7 @@ if GetOption("windows") and PLATFORMS["windows"]:
 if GetOption("windows"):
     print("Targeting foreign Windows")
     native = False
-    env = Environment(ENV=os.environ, tools=["mingw"])
+    env = Environment(tools=["mingw"])
     env.Replace(CXX="x86_64-w64-mingw32-g++")
     env.MergeFlags(shell(["x86_64-w64-mingw32-sdl2-config", "--cflags"]))
     env.MergeFlags(shell(["x86_64-w64-mingw32-sdl2-config", "--libs"]))
@@ -117,7 +116,7 @@ if GetOption("windows"):
 else:
     # native
     native = True
-    env = Environment(ENV=os.environ)
+    env = Environment()
     env.Replace(CXX=ARGUMENTS.get("CXX", "g++"))
     env.MergeFlags(shell(["sdl2-config", "--cflags"]))
     env.MergeFlags(shell(["sdl2-config", "--libs"]))


### PR DESCRIPTION
My laptop went from
```
$ time \scons a
scons: Reading SConscript files ...
Targeting native Linux/macOS
./tools/typesystem-gen.py
scons: done reading SConscript files.
scons: Building targets ...
scons: *** Do not know how to make File target `a' (/Users/gustav/smek/a).  Stop.
scons: building terminated because of errors.
\scons a  0.90s user 0.15s system 21% cpu 4.867 total
```
to
```
$ time \scons a
scons: Reading SConscript files ...
Targeting native Linux/macOS
./tools/typesystem-gen.py
scons: done reading SConscript files.
scons: Building targets ...
scons: *** Do not know how to make File target `a' (/Users/gustav/smek/a).  Stop.
scons: building terminated because of errors.
\scons a  0.94s user 0.17s system 72% cpu 1.539 total
```
with no noticeable changes, but we should make sure the env isn't needed.