### PR TITLE
Fixup the compilation database and other warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tmp
 
 # No idea, but it needs to go
 *.plist
+.ccls-cache/

--- a/src/game.h
+++ b/src/game.h
@@ -85,6 +85,7 @@ bool should_draw(GSUM gsmu);
 extern "C" void reload_game(GameState *gamestate);
 typedef void (*GameReloadFunc)(GameState *);
 
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 ///*
 // Steps the game one frame forward. Doesn't have side-effects
 // outside of the GameState object, but the new one is returned.

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -83,7 +83,6 @@ bool load_gamelib() {
         }
     }
 
-    GameLibrary next_library = {};
     dlerror(); // Clear all errors.
     void *tmp = dlopen(game_lib_path, RTLD_NOW);
     if (!tmp) {
@@ -295,7 +294,6 @@ int main(int argc, char **argv) { // Game entrypoint
         }
 
         while (next_update < SDL_GetTicks() && game_state.running) {
-            // Check for reloading of library
             game_state.time = next_update / 1000.0;
             game_state.delta = MS_PER_FRAME / 1000.0;
             game_state.frame++;


### PR DESCRIPTION
I fixed up the compilation DB to not hold duplicate commands for compilation,
this confused the poor old `ClangD` who took the compilation commands from the
end which caused `ImGui` autocompletes to not show up. I restructured a bit
in `sconstruct.py` to make it a bit more scalable, breaking up the code to make
it less of a wall of text.
