### PR TITLE
Work better for different resolutions

### DIFF
--- a/sconstruct.py
+++ b/sconstruct.py
@@ -105,6 +105,11 @@ AddOption("--no-env",
           action="store_true",
           help="Don't copy the entire environment when setting up sconstruct")
 
+AddOption("--allow-resize",
+          dest="allow_resize",
+          action="store_true",
+          help="Allow resizing of the game window")
+
 #
 # Enviroment setup
 #
@@ -296,8 +301,15 @@ if GetOption("gen_compilation_db"):
     Depends(smek_target, compd)
 
 if native:
-    AlwaysBuild(env.Alias("run", smek_target, "cd " + smek_dir + "; " + smek[0].abspath))
-    AlwaysBuild(env.Alias("debug", smek_target, "cd " + smek_dir + "; " + "gdb " + smek[0].abspath))
+    move_to_dir = "cd " + smek_dir + ";"
+
+    run_command = [move_to_dir, smek[0].abspath]
+    if GetOption("allow_resize"):
+        run_command.append("--allow-resize")
+    AlwaysBuild(env.Alias("run", smek_target,  " ".join(run_command)))
+
+    debug_command = [move_to_dir, "gdb", smek[0].abspath]
+    AlwaysBuild(env.Alias("debug", smek_target, " ".join(debug_command)))
 
     tests_runtime_flags = []
     if GetOption("ci"):

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -108,13 +108,6 @@ void draw() {
     if (GAMESTATE()->resized_window) {
         GAMESTATE()->resized_window = false;
         GFX::set_screen_resolution();
-        // TODO(ed): Is there a better set to check for the "first" screen
-        // resolution? Initalize SDL beforehand?
-        if (frame() < 10) {
-            SDL_SetWindowPosition(GAMESTATE()->window,
-                                  SDL_WINDOWPOS_CENTERED,
-                                  SDL_WINDOWPOS_CENTERED);
-        }
     }
     GFX::RenderTexture target = GFX::render_target();
     target.use();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -105,6 +105,17 @@ void update() {
 }
 
 void draw() {
+    if (GAMESTATE()->resized_window) {
+        GAMESTATE()->resized_window = false;
+        GFX::set_screen_resolution();
+        // TODO(ed): Is there a better set to check for the "first" screen
+        // resolution? Initalize SDL beforehand?
+        if (frame() < 10) {
+            SDL_SetWindowPosition(GAMESTATE()->window,
+                                  SDL_WINDOWPOS_CENTERED,
+                                  SDL_WINDOWPOS_CENTERED);
+        }
+    }
     GFX::RenderTexture target = GFX::render_target();
     target.use();
     glClearColor(0.2, 0.1, 0.3, 1); // We don't need to do this...

--- a/src/game.h
+++ b/src/game.h
@@ -47,6 +47,7 @@ struct GameState {
 
     bool running;
     bool resized_window;
+    bool allow_user_resize_window;
 
 #ifdef IMGUI_ENABLE
     ImGuiState imgui = {};

--- a/src/game.h
+++ b/src/game.h
@@ -46,6 +46,7 @@ struct GameState {
     EntityID lights[2];
 
     bool running;
+    bool resized_window;
 
 #ifdef IMGUI_ENABLE
     ImGuiState imgui = {};

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -249,11 +249,13 @@ int main(int argc, char **argv) { // Game entrypoint
     int width = 500;
     int height = 500;
     bool passed_resolution = false;
+    bool allow_resize = false;
 #define ARGUMENT(LONG, SHORT) (std::strcmp((LONG), argv[index]) == 0 || std::strcmp((SHORT), argv[index]) == 0)
     for (int index = 1; index < argc; index++) {
         if ARGUMENT ("--help", "-h") {
             std::printf("Usage: SMEK [--help] [--resolution <width> <height>]\n"
-                        "            [--no-reload]\n");
+                        "            [--no-reload]\n"
+                        "            [--allow-resize]\n");
             return 0;
         } else if ARGUMENT ("--resolution", "-r") {
             width = std::atoi(argv[++index]);
@@ -261,6 +263,8 @@ int main(int argc, char **argv) { // Game entrypoint
             passed_resolution = true;
         } else if ARGUMENT ("--no-reload", "-R") {
             hot_reload_active = false;
+        } else if ARGUMENT ("--allow-resize", "-a") {
+            allow_resize = true;
         } else {
             ERR("Unknown command line argument '{}'", argv[index]);
         }
@@ -283,6 +287,7 @@ int main(int argc, char **argv) { // Game entrypoint
     }
 
     game_state = {};
+    game_state.allow_user_resize_window = allow_resize;
     game_state.input.mouse_capture = false;
     game_state.input.rebind_func = platform_rebind;
     game_state.input.bind_func = platform_bind;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -271,6 +271,15 @@ int main(int argc, char **argv) { // Game entrypoint
     }
 #undef ARGUMENT
 
+    if (SDL_Init(SDL_INIT_EVERYTHING) != 0) {
+        ERR("Failed to initalize SDL \"{}\"", SDL_GetError());
+        return false;
+    }
+
+    if (!passed_resolution) {
+        update_to_default_window_size(&width, &height);
+    }
+
     if (hot_reload_active) {
         m_reload_lib = SDL_CreateMutex();
         ASSERT(m_reload_lib, "Unable to create mutex");
@@ -300,11 +309,6 @@ int main(int argc, char **argv) { // Game entrypoint
     platform_audio_init();
     game_state.audio_struct = &platform_audio_struct;
 
-    if (!passed_resolution && update_to_default_window_size(&width, &height)) {
-        game_state.renderer.width = width;
-        game_state.renderer.height = height;
-        game_state.resized_window = true;
-    }
 
     // IMGUI
     if (gladLoadGL() == 0) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -715,15 +715,25 @@ void remake_render_target() {
                                                               GAMESTATE()->renderer.height);
 }
 
-void set_screen_resolution(i32 width, i32 height) {
-    Renderer *r = &GAMESTATE()->renderer;
-    r->width = width;
-    r->height = height;
-    SDL_SetWindowSize(GAMESTATE()->window, r->width, r->height);
+void Renderer::set_screen_resolution(i32 new_width, i32 new_height) {
+    width = new_width;
+    height = new_height;
+
+    SDL_SetWindowSize(GAMESTATE()->window, width, height);
     remake_render_target();
 
-    r->debug_camera.set_aspect_ratio();
-    r->gameplay_camera.set_aspect_ratio();
+    debug_camera.set_aspect_ratio();
+    gameplay_camera.set_aspect_ratio();
+}
+
+void set_screen_resolution() {
+    i32 width = GAMESTATE()->renderer.width;
+    i32 height = GAMESTATE()->renderer.height;
+    GAMESTATE()->renderer.set_screen_resolution(width, height);
+}
+
+void set_screen_resolution(i32 width, i32 height) {
+    GAMESTATE()->renderer.set_screen_resolution(width, height);
 }
 
 void push_mesh(AssetID mesh, AssetID texture, Vec3 position, Quat rotation, Vec3 scale) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -664,12 +664,16 @@ bool init(GameState *gs, i32 width, i32 height) {
     gs->renderer.width = width;
     gs->renderer.height = height;
 
+    int window_flaggs = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
+    if (gs->allow_user_resize_window) {
+        window_flaggs |= SDL_WINDOW_RESIZABLE;
+    }
     gs->window = SDL_CreateWindow("SMEK - The new begining",
                                   SDL_WINDOWPOS_UNDEFINED,
                                   SDL_WINDOWPOS_UNDEFINED,
                                   width,
                                   height,
-                                  SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+                                  window_flaggs);
 
     if (gs->window == NULL) {
         ERR("Failed to create OpenGL window \"{}\"", SDL_GetError());

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -659,16 +659,16 @@ bool init(GameState *gs, i32 width, i32 height) {
     gs->renderer.width = width;
     gs->renderer.height = height;
 
-    int window_flaggs = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
+    int window_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
     if (gs->allow_user_resize_window) {
-        window_flaggs |= SDL_WINDOW_RESIZABLE;
+        window_flags |= SDL_WINDOW_RESIZABLE;
     }
     gs->window = SDL_CreateWindow("SMEK - The new begining",
                                   SDL_WINDOWPOS_UNDEFINED,
                                   SDL_WINDOWPOS_UNDEFINED,
                                   width,
                                   height,
-                                  window_flaggs);
+                                  window_flags);
 
     if (gs->window == NULL) {
         ERR("Failed to create OpenGL window \"{}\"", SDL_GetError());

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -652,11 +652,6 @@ void Texture::destroy() {
 }
 
 bool init(GameState *gs, i32 width, i32 height) {
-    if (SDL_Init(SDL_INIT_EVERYTHING) != 0) {
-        ERR("Failed to initalize SDL \"{}\"", SDL_GetError());
-        return false;
-    }
-
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -345,7 +345,7 @@ struct Lighting {
 struct Renderer {
     u32 width;
     u32 height;
-    /// Callback for platformlayer to change resolution.
+    /// Callback for platform layer to change resolution.
     void set_screen_resolution(i32 width, i32 height);
 
     RenderTexture target;

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -345,6 +345,8 @@ struct Lighting {
 struct Renderer {
     u32 width;
     u32 height;
+    /// Callback for platformlayer to change resolution.
+    void set_screen_resolution(i32 width, i32 height);
 
     RenderTexture target;
     Mesh quad;
@@ -374,6 +376,9 @@ void remake_render_target();
 
 ///*
 // Sets the screen resolution.
+// If not arguments are passed, the currently set
+// values are reloaded.
+void set_screen_resolution();
 void set_screen_resolution(i32 width, i32 height);
 
 ///*


### PR DESCRIPTION
Automatically select a decent window resolution and allow resizing of the
window if - "--allow-resize" is passed to the game.

I choose to set the default for resizability to false since it works better with i3.

Some design decisions are questionable, and if anyone can think of a smarter
way to do it I'd be happy to fix it. But I just hacked in changing of the
window size, since we cannot use SDL to get the window size before SDL is initalized,
which is where we create the window.
