### PR TITLE
Networked players

### DIFF
--- a/sconstruct.py
+++ b/sconstruct.py
@@ -110,6 +110,23 @@ AddOption("--allow-resize",
           action="store_true",
           help="Allow resizing of the game window")
 
+AddOption("--server",
+          dest="server",
+          action="store_true",
+          help="Autostart the server on startup")
+
+AddOption("--client",
+          dest="client",
+          action="store",
+          type="string",
+          help="Autostart the client and connect to the specified server")
+
+AddOption("--port",
+          dest="port",
+          action="store",
+          type="int",
+          help="Set the port used by the autostarting client or server")
+
 #
 # Enviroment setup
 #
@@ -306,6 +323,13 @@ if native:
     run_command = [move_to_dir, smek[0].abspath]
     if GetOption("allow_resize"):
         run_command.append("--allow-resize")
+    if GetOption("server"):
+        run_command.append("--server")
+    elif client := GetOption("client"):
+        run_command.append(f"--client {client}")
+    if port := GetOption("port"):
+        run_command.append(f"--port {port}")
+
     AlwaysBuild(env.Alias("run", smek_target,  " ".join(run_command)))
 
     debug_command = [move_to_dir, "gdb", smek[0].abspath]

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -134,11 +134,11 @@ void Player::update_input() {
     PlayerInput player_input;
     player_input.entity_id = this->entity_id;
     Vec2 turn = Input::mouse_move()
-        * GAMESTATE()->player_mouse_sensitivity
-        * delta();
+                * GAMESTATE()->player_mouse_sensitivity
+                * delta();
     rotation = normalized(H::from(0.0, -turn.x, 0.0)
-                            * rotation
-                            * H::from(-turn.y, 0.0, 0.0));
+                          * rotation
+                          * H::from(-turn.y, 0.0, 0.0));
     rotation.to(player_input.rotation);
     Vec3 v_move = {
         Input::value(Ac::MoveX),
@@ -176,9 +176,9 @@ void Player::update_position() {
     velocity.y += -4.82 * delta(); // temp gravity
     velocity.z = velocity.z * drag_coef;
     velocity += rotation
-        * Vec3(move.x, 0.0, move.z)
-        * GAMESTATE()->player_movement_speed
-        * delta();
+                * Vec3(move.x, 0.0, move.z)
+                * GAMESTATE()->player_movement_speed
+                * delta();
     // Plane collision
     if (position.y <= FLOOR) {
         position.y = FLOOR;
@@ -411,15 +411,15 @@ void EntitySystem::send_initial_state(ClientHandle *handle) {
     for (const auto &[_, entity] : entities) {
         bool send = true;
         switch (entity->type) {
-            case EntityType::LIGHT:
-                entity_package.EVENT.event = entity_event(static_cast<Light *>(entity));
-                break;
-            case EntityType::PLAYER:
-                entity_package.EVENT.event = entity_event(static_cast<Player *>(entity));
-                break;
-            default:
-                send = false;
-                break;
+        case EntityType::LIGHT:
+            entity_package.EVENT.event = entity_event(static_cast<Light *>(entity));
+            break;
+        case EntityType::PLAYER:
+            entity_package.EVENT.event = entity_event(static_cast<Player *>(entity));
+            break;
+        default:
+            send = false;
+            break;
         }
         if (send) {
             handle->send(&entity_package);

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -90,39 +90,85 @@ void LightUpdate::callback() {
     l->draw_as_point = draw_as_point;
 }
 
+void PlayerInput::callback() {
+    //TODO this shouldn't be bound per player.
+    //     rather, the network should check the client prefixes of players
+    if (!GAMESTATE()->entity_system.is_valid(entity_id)) {
+        WARN("Received player input for invalid entity id {}", entity_id);
+        return;
+    }
+    Player *p = GAMESTATE()->entity_system.fetch<Player>(entity_id);
+    p->last_input = *this;
+}
+
 void Player::update() {
-    const f32 floor = 0.2;
+    if (GAMESTATE()->network.server_listening) {
+        // We're the server, so parse last_input
+        const f32 floor = 0.2;
 
-    Vec2 turn = Input::mouse_move();
-    turn = turn * delta() * GAMESTATE()->player_mouse_sensitivity;
-    rotation = normalized(H::from(0.0, -turn.x, 0.0) * rotation * H::from(-turn.y, 0.0, 0.0));
-
-    f32 drag_coef = Math::pow(0.05, delta());
-    velocity.x = velocity.x * drag_coef;
-    velocity.y -= 4.82 * delta(); // Temporary gravity
-    velocity.z = velocity.z * drag_coef;
-    velocity += rotation * Vec3(Input::value(Ac::MoveX), 0.0, Input::value(Ac::MoveZ)) * GAMESTATE()->player_movement_speed * delta();
-    // Plane collision
-    if (position.y <= floor) {
-        position.y = floor;
-        velocity.y = 0.0;
-
-        // If grounded
-        if (Input::pressed(Ac::Jump) && velocity.y == 0.0) {
-            velocity.y = GAMESTATE()->player_jump_speed;
+        Vec2 turn(last_input.mouse_axis);
+        if (length_squared(turn) > 1.0) {
+            turn = turn / length(turn); //TODO /=
         }
-    }
+        turn = turn * delta(); //TODO *=
+        rotation = normalized(H::from(0.0, -turn.x, 0.0)
+                              * rotation
+                              * H::from(-turn.y, 0.0, 0.0));
 
-    if (Input::pressed(Ac::Shoot)) {
-        LOG("Pew!");
-    }
+        Vec3 move(last_input.move_axis);
+        if (length_squared(move) > 1.0) {
+            move = move / length(move); //TODO /=
+        }
+        f32 drag_coef = Math::pow(0.05, delta());
+        velocity.x = velocity.x * drag_coef;
+        velocity.y = -4.82 * delta(); // temp gravity
+        velocity.z = velocity.z * drag_coef;
+        velocity += rotation
+            * Vec3(move.x, 0.0, move.z)
+            * GAMESTATE()->player_movement_speed
+            * delta();
+        // Plane collision
+        if (position.y <= floor) {
+            position.y = floor;
+            velocity.y = 0.0;
 
-    if (GFX::current_camera() != GFX::debug_camera()) {
+            // If grounded
+            if (last_input.jump && velocity.y == 0.0) {
+                velocity.y = GAMESTATE()->player_jump_speed;
+            }
+        }
+        if (last_input.shot) {
+            LOG("Pew!");
+        }
         position += velocity * delta();
-    }
+    } else if (GAMESTATE()->entity_system.have_ownership(entity_id)) {
+        // we're a client updating our own player, so send our current inputs
+        Package pkg;
+        pkg.header.type = PackageType::EVENT;
+        pkg.EVENT.event.type = EventType::PLAYER_INPUT;
+        PlayerInput player_input;
+        player_input.entity_id = this->entity_id;
+        Vec2 v_mouse_turn = Input::mouse_move()
+            * GAMESTATE()->player_mouse_sensitivity;
+        v_mouse_turn.to(player_input.mouse_axis);
+        Vec3 v_move = {
+            Input::value(Ac::MoveX),
+            Input::value(Ac::MoveY),
+            Input::value(Ac::MoveZ),
+        };
+        v_move = v_move * GAMESTATE()->player_movement_speed; //TODO *=
+        v_move.to(player_input.move_axis);
+        player_input.jump = Input::pressed(Ac::Jump);
+        player_input.shot = Input::pressed(Ac::Shoot);
+        pkg.EVENT.event.PLAYER_INPUT = player_input;
 
-    GFX::gameplay_camera()->position = position + Vec3(0.0, 0.9, 0.0);
-    GFX::gameplay_camera()->rotation = rotation;
+        if (GAMESTATE()->network.server_handle.active) {
+            GAMESTATE()->network.server_handle.send(&pkg);
+        }
+
+        GFX::gameplay_camera()->position = position + Vec3(0.0, 0.9, 0.0);
+        GFX::gameplay_camera()->rotation = rotation;
+    }
 }
 
 IMPL_IMGUI(Player, ([&]() {

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -432,6 +432,15 @@ void EntitySystem::send_initial_state(ClientHandle *handle) {
     }
 }
 
+void EntitySystem::drop_client(u64 client_id) {
+    for (const auto &[id, entity] : entities) {
+        if ((id & CLIENT_MASK) == client_id) {
+            LOG("Dropping entity with id {}", id);
+            entity->remove = true;
+        }
+    }
+}
+
 void EntitySystem::draw() {
     draw_imgui();
     for (auto [_, e] : entities) {

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -169,6 +169,17 @@ void Player::update() {
 }
 
 IMPL_IMGUI(Player, ([&]() {
+               ImGui::VSliderFloat("Mouse x",
+                                   Vec2(18, 160),
+                                   &last_input.mouse_axis[0],
+                                   -10.0,
+                                   +10.0);
+               ImGui::SameLine(0, 10);
+               ImGui::VSliderFloat("Mouse y",
+                                   Vec2(18, 160),
+                                   &last_input.mouse_axis[1],
+                                   -10.0,
+                                   +10.0);
                ImGui::SliderFloat("Jump speed",
                                   &GAMESTATE()->player_jump_speed,
                                   0.0, 10.0,

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -409,17 +409,22 @@ void EntitySystem::send_initial_state(ClientHandle *handle) {
     LOG("Sending initial state to client");
     Package entity_package;
     entity_package.header.type = PackageType::EVENT;
-    if (is_valid(GAMESTATE()->lights[0])) {
-        entity_package.EVENT.event = entity_event(fetch<Light>(GAMESTATE()->lights[0]));
-        handle->send(&entity_package);
-    } else {
-        WARN("Not sending invalid light 0");
-    }
-    if (is_valid(GAMESTATE()->lights[1])) {
-        entity_package.EVENT.event = entity_event(fetch<Light>(GAMESTATE()->lights[1]));
-        handle->send(&entity_package);
-    } else {
-        WARN("Not sending invalid light 1");
+    for (const auto &[_, entity] : entities) {
+        bool send = true;
+        switch (entity->type) {
+            case EntityType::LIGHT:
+                entity_package.EVENT.event = entity_event(static_cast<Light *>(entity));
+                break;
+            case EntityType::PLAYER:
+                entity_package.EVENT.event = entity_event(static_cast<Player *>(entity));
+                break;
+            default:
+                send = false;
+                break;
+        }
+        if (send) {
+            handle->send(&entity_package);
+        }
     }
 }
 

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -155,6 +155,8 @@ void Player::update_input() {
 }
 
 void Player::update_position() {
+    const f32 VELOCITY_EPSILON = 0.001;
+
     Vec2 turn(last_input.mouse_axis);
     turn = turn * delta(); //TODO *=
     rotation = normalized(H::from(0.0, -turn.x, 0.0)
@@ -179,7 +181,8 @@ void Player::update_position() {
         velocity.y = 0.0;
 
         // If grounded
-        if (last_input.jump && velocity.y == 0.0) {
+        // TODO(gu) check if colliding with floor instead
+        if (last_input.jump && velocity.y < VELOCITY_EPSILON) {
             velocity.y = GAMESTATE()->player_jump_speed;
         }
     }

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -107,9 +107,6 @@ void Player::update() {
         const f32 floor = 0.2;
 
         Vec2 turn(last_input.mouse_axis);
-        if (length_squared(turn) > 1.0) {
-            turn = turn / length(turn); //TODO /=
-        }
         turn = turn * delta(); //TODO *=
         rotation = normalized(H::from(0.0, -turn.x, 0.0)
                               * rotation

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -167,7 +167,7 @@ void Player::update_position() {
     }
     f32 drag_coef = Math::pow(0.05, delta());
     velocity.x = velocity.x * drag_coef;
-    velocity.y = -4.82 * delta(); // temp gravity
+    velocity.y += -4.82 * delta(); // temp gravity
     velocity.z = velocity.z * drag_coef;
     velocity += rotation
         * Vec3(move.x, 0.0, move.z)

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -91,8 +91,9 @@ void LightUpdate::callback() {
 }
 
 void PlayerInput::callback() {
-    //TODO this shouldn't be bound per player.
-    //     rather, the network should check the client prefixes of players
+    // This could be per client instead. In that case we would iterate all
+    // players and compare their entity id client id prefix with the network
+    // client id prefix.
     if (!GAMESTATE()->entity_system.is_valid(entity_id)) {
         WARN("Received player input for invalid entity id {}", entity_id);
         return;

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -123,6 +123,7 @@ struct ClientHandle;
 ///*
 struct EntitySystem {
     static const u64 ID_MASK = 0x00FFFFFFFFFFFFFF;
+    static const u64 CLIENT_MASK = 0xFF00000000000000;
     SDL_mutex *m_client_id;
     u64 client_id = 0;
     u64 id_counter = 0;
@@ -148,6 +149,9 @@ struct EntitySystem {
     void send_state(ClientHandle *handle);
     void send_initial_state(ClientHandle *handle);
     void update();
+
+    // Remove all entities owned by client_id
+    void drop_client(u64 client_id);
 
     template <typename E>
     E *fetch(EntityID id);

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -107,6 +107,13 @@ struct Player : public Entity {
     void draw() override;
 };
 
+struct PlayerUpdate {
+    EntityID entity_id;
+    real position[3];
+    real rotation[4];
+    void callback();
+};
+
 struct ServerHandle;
 struct ClientHandle;
 ///*

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -88,7 +88,7 @@ struct LightUpdate {
 
 struct PlayerInput {
     EntityID entity_id;
-    f32 mouse_axis[2]; // mouse sensitivity included
+    f32 rotation[4];
     f32 move_axis[3];
     bool jump;
     bool shot;

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -86,9 +86,19 @@ struct LightUpdate {
     void callback();
 };
 
+struct PlayerInput {
+    EntityID entity_id;
+    f32 mouse_axis[2]; // mouse sensitivity included
+    f32 move_axis[3];
+    bool jump;
+    bool shot;
+    void callback();
+};
+
 ///*
 // A playable character
 struct Player : public Entity {
+    PlayerInput last_input;
     Vec3 velocity;
 
     void imgui() override;

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -98,12 +98,16 @@ struct PlayerInput {
 ///*
 // A playable character
 struct Player : public Entity {
+    static constexpr f32 FLOOR = 0.2;
     PlayerInput last_input;
     Vec3 velocity;
 
     void imgui() override;
 
     void update() override;
+    void update_camera();
+    void update_input();
+    void update_position();
     void draw() override;
 };
 

--- a/src/entity/entity_editor.cpp
+++ b/src/entity/entity_editor.cpp
@@ -191,4 +191,3 @@ void EntitySystem::draw_imgui() {
 #else
 void EntitySystem::draw_imgui() {}
 #endif
-

--- a/src/entity/entity_types.cpp
+++ b/src/entity/entity_types.cpp
@@ -203,7 +203,7 @@ Event entity_event(BaseEntity *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::BASEENTITY
+            .type = EntityType::BASEENTITY,
         }
     };
     std::memcpy(event.CREATE_ENTITY.BASEENTITY, ((u8 *)entity) + sizeof(u8 *), sizeof(BaseEntity) - sizeof(u8 *));
@@ -219,7 +219,7 @@ Event entity_event(Entity *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::ENTITY
+            .type = EntityType::ENTITY,
         }
     };
     std::memcpy(event.CREATE_ENTITY.ENTITY, ((u8 *)entity) + sizeof(u8 *), sizeof(Entity) - sizeof(u8 *));
@@ -235,7 +235,7 @@ Event entity_event(Light *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::LIGHT
+            .type = EntityType::LIGHT,
         }
     };
     std::memcpy(event.CREATE_ENTITY.LIGHT, ((u8 *)entity) + sizeof(u8 *), sizeof(Light) - sizeof(u8 *));
@@ -251,7 +251,7 @@ Event entity_event(Player *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::PLAYER
+            .type = EntityType::PLAYER,
         }
     };
     std::memcpy(event.CREATE_ENTITY.PLAYER, ((u8 *)entity) + sizeof(u8 *), sizeof(Player) - sizeof(u8 *));
@@ -267,7 +267,7 @@ Event entity_event(SoundEntity *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::SOUNDENTITY
+            .type = EntityType::SOUNDENTITY,
         }
     };
     std::memcpy(event.CREATE_ENTITY.SOUNDENTITY, ((u8 *)entity) + sizeof(u8 *), sizeof(SoundEntity) - sizeof(u8 *));

--- a/src/entity/entity_types.cpp
+++ b/src/entity/entity_types.cpp
@@ -28,6 +28,7 @@ FieldNameType audio_id = "audio_id";
 FieldNameType color = "color";
 FieldNameType draw_as_point = "draw_as_point";
 FieldNameType entity_id = "entity_id";
+FieldNameType last_input = "last_input";
 FieldNameType light_id = "light_id";
 FieldNameType position = "position";
 FieldNameType remove = "remove";
@@ -69,6 +70,7 @@ Field gen_Player[] = {
     { typeid(Vec3), FieldName::position, sizeof(Vec3), (int)offsetof(Player, position) },
     { typeid(Vec3), FieldName::scale, sizeof(Vec3), (int)offsetof(Player, scale) },
     { typeid(Quat), FieldName::rotation, sizeof(Quat), (int)offsetof(Player, rotation) },
+    { typeid(PlayerInput), FieldName::last_input, sizeof(PlayerInput), (int)offsetof(Player, last_input) },
     { typeid(Vec3), FieldName::velocity, sizeof(Vec3), (int)offsetof(Player, velocity) }
 };
 Field gen_SoundEntity[] = {

--- a/src/entity/entity_types.h
+++ b/src/entity/entity_types.h
@@ -30,6 +30,7 @@ extern FieldNameType audio_id;
 extern FieldNameType color;
 extern FieldNameType draw_as_point;
 extern FieldNameType entity_id;
+extern FieldNameType last_input;
 extern FieldNameType light_id;
 extern FieldNameType position;
 extern FieldNameType remove;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -18,6 +18,7 @@ void handle_events() {
         switch (e.type) {
             HANDLE(CREATE_ENTITY);
             HANDLE(LIGHT_UPDATE);
+            HANDLE(PLAYER_INPUT);
         default:
             ERR("Unkown event type {}", e.type);
         }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -19,6 +19,7 @@ void handle_events() {
             HANDLE(CREATE_ENTITY);
             HANDLE(LIGHT_UPDATE);
             HANDLE(PLAYER_INPUT);
+            HANDLE(PLAYER_UPDATE);
         default:
             ERR("Unkown event type {}", e.type);
         }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -20,6 +20,7 @@ void handle_events() {
             HANDLE(LIGHT_UPDATE);
             HANDLE(PLAYER_INPUT);
             HANDLE(PLAYER_UPDATE);
+            HANDLE(DROP_CLIENT);
         default:
             ERR("Unkown event type {}", e.type);
         }

--- a/src/event.h
+++ b/src/event.h
@@ -10,6 +10,7 @@ enum EventType {
     CREATE_ENTITY,
     LIGHT_UPDATE,
     PLAYER_INPUT,
+    PLAYER_UPDATE,
 
     _NUM_TYPES,
 };
@@ -17,7 +18,8 @@ enum EventType {
 static const char *event_type_names[] = {
     "CreateEntity",
     "Update light",
-    "Player input"
+    "Player input",
+    "Player update",
 };
 
 static_assert(!(LEN(event_type_names) < (u64)EventType::_NUM_TYPES), "Too few event type names");
@@ -29,6 +31,7 @@ struct Event {
         EventCreateEntity CREATE_ENTITY;
         LightUpdate LIGHT_UPDATE;
         PlayerInput PLAYER_INPUT;
+        PlayerUpdate PLAYER_UPDATE;
     };
 };
 

--- a/src/event.h
+++ b/src/event.h
@@ -9,13 +9,15 @@
 enum EventType {
     CREATE_ENTITY,
     LIGHT_UPDATE,
+    PLAYER_INPUT,
 
     _NUM_TYPES,
 };
 
 static const char *event_type_names[] = {
     "CreateEntity",
-    "Update light"
+    "Update light",
+    "Player input"
 };
 
 static_assert(!(LEN(event_type_names) < (u64)EventType::_NUM_TYPES), "Too few event type names");
@@ -26,6 +28,7 @@ struct Event {
     union {
         EventCreateEntity CREATE_ENTITY;
         LightUpdate LIGHT_UPDATE;
+        PlayerInput PLAYER_INPUT;
     };
 };
 

--- a/src/event.h
+++ b/src/event.h
@@ -5,12 +5,14 @@
 #include "math/smek_math.h"
 #include "entity/entity.h"
 #include "entity/entity_types.h"
+#include "network/events.h"
 
 enum EventType {
     CREATE_ENTITY,
     LIGHT_UPDATE,
     PLAYER_INPUT,
     PLAYER_UPDATE,
+    DROP_CLIENT,
 
     _NUM_TYPES,
 };
@@ -20,6 +22,7 @@ static const char *event_type_names[] = {
     "Update light",
     "Player input",
     "Player update",
+    "Drop client",
 };
 
 static_assert(!(LEN(event_type_names) < (u64)EventType::_NUM_TYPES), "Too few event type names");
@@ -32,6 +35,7 @@ struct Event {
         LightUpdate LIGHT_UPDATE;
         PlayerInput PLAYER_INPUT;
         PlayerUpdate PLAYER_UPDATE;
+        DropClientEvent DROP_CLIENT;
     };
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -63,7 +63,7 @@ void init_game(GameState *gamestate, int width, int height) {
     GAMESTATE()->lights[1] = GAMESTATE()->entity_system.add(l);
 
     Player player = {};
-    GAMESTATE()->entity_system.add(player);
+    //GAMESTATE()->entity_system.add(player);
 
     Physics::AABody b;
     b.position = { 0, 0, 0 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -30,6 +30,9 @@ void init_game(GameState *gamestate, int width, int height) {
     GAMESTATE()->entity_system.m_client_id = SDL_CreateMutex();
     GAMESTATE()->m_event_queue = SDL_CreateMutex();
 
+    Player player = {};
+    GAMESTATE()->entity_system.add(player);
+
     Network *n = &GAMESTATE()->network;
     if (n->autostart_server) {
         n->setup_server(n->autostart_port);
@@ -68,9 +71,6 @@ void init_game(GameState *gamestate, int width, int height) {
     Light l = Light();
     GAMESTATE()->lights[0] = GAMESTATE()->entity_system.add(l);
     GAMESTATE()->lights[1] = GAMESTATE()->entity_system.add(l);
-
-    Player player = {};
-    //GAMESTATE()->entity_system.add(player);
 
     Physics::AABody b;
     b.position = { 0, 0, 0 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -30,6 +30,13 @@ void init_game(GameState *gamestate, int width, int height) {
     GAMESTATE()->entity_system.m_client_id = SDL_CreateMutex();
     GAMESTATE()->m_event_queue = SDL_CreateMutex();
 
+    Network *n = &GAMESTATE()->network;
+    if (n->autostart_server) {
+        n->setup_server(n->autostart_port);
+    } else if (n->autostart_client) {
+        n->connect_to_server(n->client_server_addr, n->autostart_port);
+    }
+
     Asset::load("assets.bin");
 
 #if IMGUI_ENABLE

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -89,7 +89,7 @@ void reload_game(GameState *game) {
     GFX::remake_render_target();
 }
 
-void on_connect() {
+void on_connect_to_server() {
     Player player = {};
     player.entity_id = GAMESTATE()->entity_system.add(player);
     Package player_package;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -82,6 +82,15 @@ void reload_game(GameState *game) {
     GFX::remake_render_target();
 }
 
+void on_connect() {
+    Player player = {};
+    player.entity_id = GAMESTATE()->entity_system.add(player);
+    Package player_package;
+    player_package.header.type = PackageType::EVENT;
+    player_package.EVENT.event = entity_event(player);
+    GAMESTATE()->network.server_handle.send(&player_package);
+}
+
 void update() {
     if (Input::released(Ac::MouseToggle)) {
         GAMESTATE()->input.mouse_capture ^= 1;

--- a/src/game.h
+++ b/src/game.h
@@ -67,7 +67,7 @@ GameState *GAMESTATE();
 extern "C" void init_game(GameState *gamestate, int width, int height);
 typedef void (*GameInitFunc)(GameState *, int, int);
 
-void on_connect();
+void on_connect_to_server();
 
 struct GameStateUpdateMode {
     bool draw = false;

--- a/src/game.h
+++ b/src/game.h
@@ -67,6 +67,8 @@ GameState *GAMESTATE();
 extern "C" void init_game(GameState *gamestate, int width, int height);
 typedef void (*GameInitFunc)(GameState *, int, int);
 
+void on_connect();
+
 struct GameStateUpdateMode {
     bool draw = false;
     bool update = false;

--- a/src/imgui_state.h
+++ b/src/imgui_state.h
@@ -25,4 +25,5 @@ struct ImGuiState {
         int width;
         int height;
     } screen_resolution = {};
+    int network_port = 8888;
 };

--- a/src/math/smek_quat.cpp
+++ b/src/math/smek_quat.cpp
@@ -11,10 +11,10 @@ i32 format(char *buffer, u32 size, FormatHint args, H q) {
 }
 
 void H::to(real *arr) const {
-    arr[0] = _[0];
-    arr[1] = _[1];
-    arr[2] = _[2];
-    arr[3] = _[3];
+    arr[0] = x;
+    arr[1] = y;
+    arr[2] = z;
+    arr[3] = w;
 }
 
 real &H::operator[](std::size_t idx) {

--- a/src/network/events.h
+++ b/src/network/events.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../math/smek_math.h"
+
+// Created when a client is dropped so the main thread can do clean-up
+struct DropClientEvent {
+    u64 client_id;
+    void callback();
+};

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -100,7 +100,7 @@ int start_server_handle(void *data) {
                     GAMESTATE()->entity_system.client_id = handle->client_id;
                     SDL_UnlockMutex(GAMESTATE()->entity_system.m_client_id);
                 }
-                on_connect();
+                on_connect_to_server();
                 break;
             case PackageType::HEARTBEAT:
                 handle->recv_heartbeat(package.HEARTBEAT.id);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -18,7 +18,7 @@ void NetworkHandle::send(u8 *data, u32 data_len) {
 }
 
 void NetworkHandle::send(Package *package) {
-    u8 buf[sizeof(Package)];
+    u8 buf[sizeof(Package)] = {};
     package->header.client = client_id;
     package->header.id = next_package_id++;
     pack(buf, package);
@@ -100,6 +100,7 @@ int start_server_handle(void *data) {
                     GAMESTATE()->entity_system.client_id = handle->client_id;
                     SDL_UnlockMutex(GAMESTATE()->entity_system.m_client_id);
                 }
+                on_connect();
                 break;
             case PackageType::HEARTBEAT:
                 handle->recv_heartbeat(package.HEARTBEAT.id);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -283,13 +283,10 @@ void Network::imgui_draw() {
     if (!GAMESTATE()->imgui.networking_enabled) return;
     ImGui::Begin("Networking");
     {
-        static int serverport = 8888;
         ImGui::SetNextItemWidth(150);
-        ImGui::PushID(&serverport);
-        ImGui::InputInt("port", &serverport);
-        ImGui::PopID();
+        ImGui::InputInt("port", &GAMESTATE()->imgui.network_port);
         if (ImGui::Button("Create server")) {
-            setup_server(serverport);
+            setup_server(GAMESTATE()->imgui.network_port);
         }
         if (server_listening) {
             ImGui::SameLine();
@@ -333,15 +330,14 @@ void Network::imgui_draw() {
         ImGui::Separator();
 
         static char ip[64] = "127.0.0.1";
-        static int connectport = 8888;
         ImGui::SetNextItemWidth(150);
         ImGui::InputText("server address", ip, LEN(ip));
         ImGui::SetNextItemWidth(150);
-        ImGui::PushID(&connectport);
-        ImGui::InputInt("port", &connectport);
+        ImGui::PushID(&GAMESTATE()->imgui.network_port);
+        ImGui::InputInt("port", &GAMESTATE()->imgui.network_port);
         ImGui::PopID();
         if (ImGui::Button("Connect to server")) {
-            connect_to_server(ip, connectport);
+            connect_to_server(ip, GAMESTATE()->imgui.network_port);
         }
         if (server_handle.active) {
             ImGui::AlignTextToFramePadding();

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -62,6 +62,11 @@ struct Network {
     static const u64 HANDLE_ID_FIRST_BIT = 0x0100000000000000;
     static const u32 MAX_CLIENTS = 2;
 
+    bool autostart_server = false;
+    bool autostart_client = false;
+    char *client_server_addr;
+    int autostart_port = 8888;
+
     bool server_listening = false;
     SDL_Thread *listener_thread;
 

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -18,6 +18,7 @@
 #include "SDL.h"
 
 #include "package.h"
+#include "events.h"
 #include "../math/smek_math.h"
 #include "../util/util.h"
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -324,6 +324,10 @@ int main(int argc, char **argv) { // Game entrypoint
         game_state.network.client_server_addr = network_client_server_addr;
         game_state.network.autostart_port = network_port;
     }
+#ifdef IMGUI_ENABLE
+    game_state.imgui.network_port = network_port;
+#endif
+
     game_lib.init(&game_state, width, height);
     platform_audio_init();
     game_state.audio_struct = &platform_audio_struct;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -250,6 +250,10 @@ int main(int argc, char **argv) { // Game entrypoint
     int height = 500;
     bool passed_resolution = false;
     bool allow_resize = false;
+    bool network_start_server = false;
+    bool network_start_client = false;
+    char *network_client_server_addr;
+    int network_port = 8888;
 #define ARGUMENT(LONG, SHORT) (std::strcmp((LONG), argv[index]) == 0 || std::strcmp((SHORT), argv[index]) == 0)
     for (int index = 1; index < argc; index++) {
         if ARGUMENT ("--help", "-h") {
@@ -265,6 +269,13 @@ int main(int argc, char **argv) { // Game entrypoint
             hot_reload_active = false;
         } else if ARGUMENT ("--allow-resize", "-a") {
             allow_resize = true;
+        } else if ARGUMENT("--server", "-s") {
+            network_start_server = true;
+        } else if ARGUMENT("--client", "-c") {
+            network_start_client = true;
+            network_client_server_addr = argv[++index];
+        } else if ARGUMENT("--port", "-p") {
+            network_port = std::atoi(argv[++index]);
         } else {
             ERR("Unknown command line argument '{}'", argv[index]);
         }
@@ -305,6 +316,14 @@ int main(int argc, char **argv) { // Game entrypoint
     game_state.m_reload_lib = m_reload_lib;
     game_state.reload_lib = &reload_lib;
 
+    if (network_start_server) {
+        game_state.network.autostart_server = true;
+        game_state.network.autostart_port = network_port;
+    } else if (network_start_client) {
+        game_state.network.autostart_client = true;
+        game_state.network.client_server_addr = network_client_server_addr;
+        game_state.network.autostart_port = network_port;
+    }
     game_lib.init(&game_state, width, height);
     platform_audio_init();
     game_state.audio_struct = &platform_audio_struct;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -269,12 +269,12 @@ int main(int argc, char **argv) { // Game entrypoint
             hot_reload_active = false;
         } else if ARGUMENT ("--allow-resize", "-a") {
             allow_resize = true;
-        } else if ARGUMENT("--server", "-s") {
+        } else if ARGUMENT ("--server", "-s") {
             network_start_server = true;
-        } else if ARGUMENT("--client", "-c") {
+        } else if ARGUMENT ("--client", "-c") {
             network_start_client = true;
             network_client_server_addr = argv[++index];
-        } else if ARGUMENT("--port", "-p") {
+        } else if ARGUMENT ("--port", "-p") {
             network_port = std::atoi(argv[++index]);
         } else {
             ERR("Unknown command line argument '{}'", argv[index]);
@@ -331,7 +331,6 @@ int main(int argc, char **argv) { // Game entrypoint
     game_lib.init(&game_state, width, height);
     platform_audio_init();
     game_state.audio_struct = &platform_audio_struct;
-
 
     // IMGUI
     if (gladLoadGL() == 0) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) { // Test entry point
     return _global_tests.run(ci, write_report, report_path);
 }
 
-void init_tests_state(GameState *tests_state ) {
+void init_tests_state(GameState *tests_state) {
     tests_state->entity_system.m_client_id = SDL_CreateMutex();
 }
 

--- a/tools/entity_types_event.cpp
+++ b/tools/entity_types_event.cpp
@@ -7,7 +7,7 @@ Event entity_event($entity_type *entity, bool generate_id) {
         .type = EventType::CREATE_ENTITY,
         .CREATE_ENTITY = {
             .generate_id = generate_id,
-            .type = EntityType::$entity_type_enum
+            .type = EntityType::$entity_type_enum,
         }
     };
     std::memcpy(event.CREATE_ENTITY.${entity_type_enum}, ((u8 *)entity) + sizeof(u8 *), sizeof($entity_type) - sizeof(u8 *));

--- a/tools/struct.lark
+++ b/tools/struct.lark
@@ -14,7 +14,7 @@ _member: field
       | struct
       | ";"
 
-field: STATIC? CONST? TYPE POINTER* NAME ("[" INT? "]")? ("=" INITIALIZER_VALUE)? ";"
+field: STATIC? (CONST? | CONSTEXPR?) TYPE POINTER* NAME ("[" INT? "]")? ("=" INITIALIZER_VALUE)? ";"
 
 method: VIRTUAL? (TYPE | DESTRUCTOR)? NAME "(" PARAMETERS? ")" OVERRIDE? "{" METHOD_BODY? "}" ";"?
       | VIRTUAL? (TYPE | DESTRUCTOR)? NAME "(" PARAMETERS? ")" OVERRIDE? ";"
@@ -32,6 +32,7 @@ POINTER: "*"
 DESTRUCTOR: "~"
 STATIC: "static"
 CONST: "const"
+CONSTEXPR: "constexpr"
 TYPE: (ALPHANUMWORD "::")* ALPHANUMWORD
 INITIALIZER_VALUE: /[^;]+/
 VIRTUAL: "virtual"


### PR DESCRIPTION
- [x] Mouse isn't sent correctly (it has something to do with multiple screens)
- [x] Update camera at client
- [x] ~~Don't spawn player at server / at least don't send it to clients~~
- [x] ~~Spawn player if we're not a server and drop it when starting the server~~
- [x] Test two clients
  - [x] Mouse input doesn't really work when connecting from my secondary monitor. The "only on the second monitor" part is very weird and honestly a bit concerning. See comment below
  - [x] ~~Send other players when connecting~~
- [x] Jump (broken even when not connected). Was a regression.
- [x] Drop entities when disconnecting
- [ ] Segfault when client reconnects (once so far). Can't reproduce by disconnecting/reconnecting multiple times in a row, but know that there's _something_ (not-yet-reproducible) here.

Maybe for later:
- Show position of debug cameras as points (also maybe an arrow indicating where it's looking)
- Something is reversed (camera is looking backwards compared to model). Something is -1 somewhere where it shouldn't. I don't think it's in here.
- Sending other clients when connecting goes into the whole sending entities automatically when they're added to the entity system. Kinda out of scope here.