### PR TITLE
Remove RGB and XYZ

### DIFF
--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -68,9 +68,9 @@ void Light::draw() {
     if (draw_as_point) {
         if (light_id == NONE) {
             GFX::push_point(position + Vec3(0.01, 0.0, 0.0), Vec4(1.0, 0.0, 0.0, 1.0), 0.07);
-            GFX::push_point(position, Vec4(color.x, color.y, color.z, 0.2), 0.05);
+            GFX::push_point(position, Vec4(color.r, color.g, color.b, 0.2), 0.05);
         } else {
-            GFX::push_point(position, Vec4(color.x, color.y, color.z, 1.0), 0.1);
+            GFX::push_point(position, Vec4(color.r, color.g, color.b, 1.0), 0.1);
         }
     }
 }

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -67,10 +67,10 @@ IMPL_IMGUI(Light, ([&] {
 void Light::draw() {
     if (draw_as_point) {
         if (light_id == NONE) {
-            GFX::push_point(position + Vec3(0.01, 0.0, 0.0), Vec4(1.0, 0.0, 0.0, 1.0), 0.07);
-            GFX::push_point(position, Vec4(color.r, color.g, color.b, 0.2), 0.05);
+            GFX::push_point(position + Vec3(0.01, 0.0, 0.0), Color4(1.0, 0.0, 0.0, 1.0), 0.07);
+            GFX::push_point(position, Color4(color.r, color.g, color.b, 0.2), 0.05);
         } else {
-            GFX::push_point(position, Vec4(color.r, color.g, color.b, 1.0), 0.1);
+            GFX::push_point(position, Color4(color.r, color.g, color.b, 1.0), 0.1);
         }
     }
 }
@@ -239,10 +239,10 @@ void EntitySystem::update() {
         // TODO(ed): Only select the closest.
         bool hovering = manifold.t > 0;
 
-        Vec4 nothing_color = { 0., 0., 0., 1. };
-        Vec4 hovering_color = { 0., 0.5, 0.5, 1. };
-        Vec4 selected_color = { 0., 0.5, 0., 1. };
-        Vec4 selected_and_hover_color = { 0., 0.5, 0.8, 1. };
+        Color4 nothing_color = { 0., 0., 0., 1. };
+        Color4 hovering_color = { 0., 0.5, 0.5, 1. };
+        Color4 selected_color = { 0., 0.5, 0., 1. };
+        Color4 selected_and_hover_color = { 0., 0.5, 0.8, 1. };
 
         if (hovering && Input::pressed(Ac::ESelect)) {
             if (selected.contains(id))

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -223,7 +223,7 @@ void do_imgui_stuff() {
     if (GAMESTATE()->imgui.show_grid) {
         const i32 grid_size = 10;
         const f32 width = 0.005;
-        const Vec4 color = GFX::color(7) * 0.4;
+        const Color4 color = GFX::color(7) * 0.4;
         for (f32 x = 0; x <= grid_size; x += 0.5) {
             GFX::push_line(Vec3(x, 0, grid_size), Vec3(x, 0, -grid_size), color, width);
             GFX::push_line(Vec3(-x, 0, grid_size), Vec3(-x, 0, -grid_size), color, width);

--- a/src/math/smek_mat4.cpp
+++ b/src/math/smek_mat4.cpp
@@ -24,14 +24,14 @@ i32 format(char *buffer, u32 size, FormatHint args, Mat &m) {
                     p, m._[3][0], p, m._[3][1], p, m._[3][2], p, m._[3][3]);
 }
 
-void Mat::gfx_dump(Vec4 color) {
+void Mat::gfx_dump(Color4 color) {
     Vec3 o = *this * Vec3(0, 0, 0);
     Vec3 x = *this * Vec3(1, 0, 0);
     Vec3 y = *this * Vec3(0, 1, 0);
     Vec3 z = *this * Vec3(0, 0, 1);
-    GFX::push_line(o, x, color, Vec4(1, 0, 0, 1), 0.01);
-    GFX::push_line(o, y, color, Vec4(0, 1, 0, 1), 0.01);
-    GFX::push_line(o, z, color, Vec4(0, 0, 1, 1), 0.01);
+    GFX::push_line(o, x, color, Color4(1, 0, 0, 1), 0.01);
+    GFX::push_line(o, y, color, Color4(0, 1, 0, 1), 0.01);
+    GFX::push_line(o, z, color, Color4(0, 0, 1, 1), 0.01);
 }
 
 Mat operator*(const Mat &a, const Mat &b) {

--- a/src/math/smek_mat4.h
+++ b/src/math/smek_mat4.h
@@ -54,7 +54,7 @@ struct Mat {
 
     static Mat from(H h);
 
-    void gfx_dump(Vec4 color = Vec4(1.0, 1.0, 1.0, 1.0));
+    void gfx_dump(Color4 color = Color4(1.0, 1.0, 1.0, 1.0));
 
     Mat invert();
     Mat transpose();

--- a/src/math/smek_vec.cpp
+++ b/src/math/smek_vec.cpp
@@ -227,3 +227,15 @@ TEST_CASE("Vec2 from array", {
     Vec4 v({ 1, 2, 3, 4 });
     return v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4;
 });
+
+TEST_CASE("Color3 -> Color4", {
+    Color3 a(1, 1, 1);
+    Color4 b = a;
+    return b[0] == 1 && b[1] == 1 && b[2] == 1 && b[3] == 1;
+});
+
+TEST_CASE("Color4 -> Color3", {
+    Color4 a(1, 1, 1, 0);
+    Color3 b = (Color3)a;
+    return b[0] == 1 && b[1] == 1 && b[2] == 1;
+});

--- a/src/math/smek_vec.cpp
+++ b/src/math/smek_vec.cpp
@@ -32,6 +32,12 @@ void Color4::to(real *arr) const {
     arr[3] = a;
 }
 
+// Since Color4 is defined _after_ Color3, we cannot access Color4s constructor
+// without it being defined.
+Color3::operator Color4() const {
+    return Color4(r, g, b, 1.0);
+}
+
 real &Vec2::operator[](std::size_t idx) {
     ASSERT_LT(idx, 2);
     return _[idx];
@@ -41,6 +47,16 @@ real &Vec3::operator[](std::size_t idx) {
     return _[idx];
 }
 real &Vec4::operator[](std::size_t idx) {
+    ASSERT_LT(idx, 4);
+    return _[idx];
+}
+
+real &Color3::operator[](std::size_t idx) {
+    ASSERT_LT(idx, 3);
+    return _[idx];
+}
+
+real &Color4::operator[](std::size_t idx) {
     ASSERT_LT(idx, 4);
     return _[idx];
 }

--- a/src/math/smek_vec.cpp
+++ b/src/math/smek_vec.cpp
@@ -20,16 +20,16 @@ void Vec4::to(real *arr) const {
 }
 
 void Color3::to(real *arr) const {
-    arr[0] = x;
-    arr[1] = y;
-    arr[2] = z;
+    arr[0] = r;
+    arr[1] = g;
+    arr[2] = b;
 }
 
 void Color4::to(real *arr) const {
-    arr[0] = x;
-    arr[1] = y;
-    arr[2] = z;
-    arr[3] = w;
+    arr[0] = r;
+    arr[1] = g;
+    arr[2] = b;
+    arr[3] = a;
 }
 
 real &Vec2::operator[](std::size_t idx) {
@@ -208,6 +208,6 @@ TEST_CASE("Vec3 from array", {
     return v[0] == 1 && v[1] == 2 && v[2] == 3;
 });
 TEST_CASE("Vec2 from array", {
-    Vec4 v({ 1, 2, 3, 4});
+    Vec4 v({ 1, 2, 3, 4 });
     return v[0] == 1 && v[1] == 2 && v[2] == 3 && v[3] == 4;
 });

--- a/src/math/smek_vec.h
+++ b/src/math/smek_vec.h
@@ -74,11 +74,16 @@ struct Vec4 {
     static Vec4 from(real *arr) { return { arr[0], arr[1], arr[2], arr[3] }; }
 };
 
+struct Color4;
 struct Color3 {
     Color3(real r = 0.0, real g = 0.0, real b = 0.0)
         : r(r)
         , g(g)
         , b(b) {}
+    Color3(Vec3 source)
+        : r(source.x)
+        , g(source.y)
+        , b(source.z) {}
     Color3(real *arr)
         : r(arr[0])
         , g(arr[1])
@@ -90,6 +95,8 @@ struct Color3 {
             real r, g, b;
         };
     };
+
+    operator Color4() const;
 
     void to(real *arr) const;
     real &operator[](std::size_t idx);
@@ -103,18 +110,27 @@ struct Color4 {
         , g(g)
         , b(b)
         , a(a) {}
+    Color4(Vec4 source)
+        : r(source.x)
+        , g(source.y)
+        , b(source.z)
+        , a(source.w) {}
     Color4(real *arr)
         : r(arr[0])
         , g(arr[1])
         , b(arr[2])
         , a(arr[3]) {}
-
     union {
         real _[4];
         struct {
             real r, g, b, a;
         };
     };
+
+    // Explicit since the alpha channel is destroyed.
+    explicit operator Color3() const {
+        return Color3(r, g, b);
+    }
 
     void to(real *arr) const;
     real &operator[](std::size_t idx);

--- a/src/math/smek_vec.h
+++ b/src/math/smek_vec.h
@@ -20,9 +20,6 @@ struct Vec2 {
         struct {
             real x, y;
         };
-        struct {
-            real r, g;
-        };
     };
 
     void to(real *arr) const;
@@ -43,9 +40,6 @@ struct Vec3 {
         real _[3];
         struct {
             real x, y, z;
-        };
-        struct {
-            real r, g, b;
         };
     };
 
@@ -72,9 +66,6 @@ struct Vec4 {
         struct {
             real x, y, z, w;
         };
-        struct {
-            real r, g, b, a;
-        };
     };
 
     void to(real *arr) const;
@@ -97,9 +88,6 @@ struct Color3 {
         real _[3];
         struct {
             real r, g, b;
-        };
-        struct {
-            real x, y, z;
         };
     };
 
@@ -125,9 +113,6 @@ struct Color4 {
         real _[4];
         struct {
             real r, g, b, a;
-        };
-        struct {
-            real x, y, z, w;
         };
     };
 

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -4,7 +4,7 @@
 
 namespace Physics {
 
-void draw_aabody(AABody a, Vec4 color) {
+void draw_aabody(AABody a, Color4 color) {
     Vec3 p = a.position;
     Vec3 r = a.half_size;
     Vec3 points[] = {
@@ -29,7 +29,7 @@ void draw_aabody(AABody a, Vec4 color) {
     }
 }
 
-void draw_manifold(Manifold a, Vec4 color) {
+void draw_manifold(Manifold a, Color4 color) {
     if (a) {
         GFX::push_point(a.point, color, 0.04);
         GFX::push_line(a.point, a.point + a.normal, color, 0.005);
@@ -218,7 +218,7 @@ void PhysicsEngine::update(real delta) {
 
 void PhysicsEngine::draw() {
     for (AABody &a : bodies) {
-        draw_aabody(a, Vec4(1.0, 0.0, 1.0, 1.0));
+        draw_aabody(a, Color4(1.0, 0.0, 1.0, 1.0));
     }
 }
 

--- a/src/physics/physics.h
+++ b/src/physics/physics.h
@@ -60,12 +60,12 @@ struct PhysicsEngine {
 
 ///* draw_aabody
 // Draws a body as a box.
-void draw_aabody(AABody a, Vec4 color);
+void draw_aabody(AABody a, Color4 color);
 
 ///* draw_manifold
 // Draws a collision manifold as a position and a normal.
 // Position might not match "real" position.
-void draw_manifold(Manifold a, Vec4 color);
+void draw_manifold(Manifold a, Color4 color);
 
 ///* collision_aabb
 // Check the collisions between two bodies.

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -132,34 +132,34 @@ void RenderTexture::use() {
     glViewport(0, 0, width, height);
 }
 
-const Vec4 color_list[] = {
+const Color4 color_list[] = {
 #if 0
-    Vec4(1.0, 0.0, 1.0, 1.0),
-    Vec4(115, 63, 155, 255) / 255.0,
-    Vec4(68, 73, 163, 255) / 255.0,
-    Vec4(61, 120, 157, 255) / 255.0,
-    Vec4(51, 102, 97, 255) / 255.0,
-    Vec4(155, 126, 63, 255) / 255.0,
-    Vec4(163, 74, 68, 255) / 255.0,
-    Vec4(158, 61, 109, 255) / 255.0,
-    Vec4(102, 51, 101, 255) / 255.0,
+    Color4(1.0, 0.0, 1.0, 1.0),
+    Color4(115, 63, 155, 255) / 255.0,
+    Color4(68, 73, 163, 255) / 255.0,
+    Color4(61, 120, 157, 255) / 255.0,
+    Color4(51, 102, 97, 255) / 255.0,
+    Color4(155, 126, 63, 255) / 255.0,
+    Color4(163, 74, 68, 255) / 255.0,
+    Color4(158, 61, 109, 255) / 255.0,
+    Color4(102, 51, 101, 255) / 255.0,
 #else
-    Vec4(0.0, 0.0, 0.0, 1.0),
-    Vec4(1.0, 0.0, 0.0, 1.0),
-    Vec4(0.0, 1.0, 0.0, 1.0),
-    Vec4(0.0, 0.0, 1.0, 1.0),
-    Vec4(1.0, 1.0, 0.0, 1.0),
-    Vec4(0.0, 1.0, 1.0, 1.0),
-    Vec4(1.0, 0.0, 1.0, 1.0),
-    Vec4(1.0, 0.0, 1.0, 1.0),
+    Color4(0.0, 0.0, 0.0, 1.0),
+    Color4(1.0, 0.0, 0.0, 1.0),
+    Color4(0.0, 1.0, 0.0, 1.0),
+    Color4(0.0, 0.0, 1.0, 1.0),
+    Color4(1.0, 1.0, 0.0, 1.0),
+    Color4(0.0, 1.0, 1.0, 1.0),
+    Color4(1.0, 0.0, 1.0, 1.0),
+    Color4(1.0, 0.0, 1.0, 1.0),
 #endif
 };
 
-Vec4 color(u32 index) {
+Color4 color(u32 index) {
     return color_list[index % LEN(color_list)];
 }
 
-void push_point(Vec3 a, Vec4 c, f32 width) {
+void push_point(Vec3 a, Color4 c, f32 width) {
     Vec3 z = normalized(current_camera()->position - a);
     Vec3 x = Vec3(0.0, 1.0, 0.0);
     Vec3 y = cross(x, z);
@@ -178,11 +178,11 @@ void push_point(Vec3 a, Vec4 c, f32 width) {
     push_debug_triangle(p1, c, p3, c, p4, c);
 }
 
-void push_line(Vec3 a, Vec3 b, Vec4 color, f32 width) {
+void push_line(Vec3 a, Vec3 b, Color4 color, f32 width) {
     push_line(a, b, color, color, width);
 }
 
-void push_line(Vec3 a, Vec3 b, Vec4 a_color, Vec4 b_color, f32 width) {
+void push_line(Vec3 a, Vec3 b, Color4 a_color, Color4 b_color, f32 width) {
     Vec3 z = current_camera()->position - a;
     Vec3 x = a - b;
     Vec3 y = normalized(cross(x, z));
@@ -298,7 +298,7 @@ void Skeleton::draw() {
     // TODO(ed): This can be made better since the order 0...n will allways result
     // in correct updated animations.
     for (i32 i = 0; i < (i32)num_bones; i++) {
-        Vec4 color = i == 0 ? Vec4(0, 0, 0, 1) : Vec4(1, 1, 1, 1);
+        Color4 color = i == 0 ? Color4(0, 0, 0, 1) : Color4(1, 1, 1, 1);
         matrix(i).gfx_dump(color);
     }
 }
@@ -831,7 +831,7 @@ void DebugPrimitive::clear() {
     size = 0;
 }
 
-void push_debug_triangle(Vec3 p1, Vec4 c1, Vec3 p2, Vec4 c2, Vec3 p3, Vec4 c3) {
+void push_debug_triangle(Vec3 p1, Color4 c1, Vec3 p2, Color4 c2, Vec3 p3, Color4 c3) {
     Renderer *renderer = &GAMESTATE()->renderer;
     while (!renderer->primitives[renderer->first_empty].push_triangle({ p1, c1 }, { p2, c2 }, { p3, c3 })) {
         if (++renderer->first_empty == renderer->primitives.size())

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -310,7 +310,7 @@ Camera *gameplay_camera();
 struct DebugPrimitive {
     struct Vertex {
         Vec3 position;
-        Vec4 color;
+        Color4 color;
     };
     static const u32 VERTS_PER_BUFFER = 300;
 
@@ -407,21 +407,21 @@ void deinit(GameState *gs);
 ///*
 // Returns a nice color, garanteed to match other
 // colors returned from here.
-Vec4 color(u32 index = 0);
+Color4 color(u32 index = 0);
 
 ///*
 // Draws a point in a with color c.
-void push_point(Vec3 a, Vec4 c = color(), f32 width = 0.1);
+void push_point(Vec3 a, Color4 c = color(), f32 width = 0.1);
 
 ///*
 // Draws a line form A to B, in the given color.
-void push_line(Vec3 a, Vec3 b, Vec4 c = color(), f32 width = 0.1);
-void push_line(Vec3 a, Vec3 b, Vec4 a_color, Vec4 b_color, f32 width = 0.1);
+void push_line(Vec3 a, Vec3 b, Color4 c = color(), f32 width = 0.1);
+void push_line(Vec3 a, Vec3 b, Color4 a_color, Color4 b_color, f32 width = 0.1);
 
 ///*
 // Adds one triangle to be drawn during
 // the debug render call.
-void push_debug_triangle(Vec3 p1, Vec4 c1, Vec3 p2, Vec4 c2, Vec3 p3, Vec4 c3);
+void push_debug_triangle(Vec3 p1, Color4 c1, Vec3 p2, Color4 c2, Vec3 p3, Color4 c3);
 
 ///*
 // Renders the debug primitivs to the screen.


### PR DESCRIPTION
Closes #203
Removes RGB fields from Vector types and XYZ fields from Color types.

Also adds some bits and bobs to make life using them easier, like automatic
upcasting of Colors.

