### PR TITLE
thread safe performance

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -8,6 +8,7 @@
 #include "physics/physics.h"
 #include "entity/entity.h"
 #include "network/network.h"
+#include "util/performance.h"
 
 #include <queue>
 
@@ -52,6 +53,16 @@ struct GameState {
 
 #ifdef IMGUI_ENABLE
     ImGuiState imgui = {};
+#endif
+
+#ifdef PERFORMANCE_ENABLE
+    struct PerformanceStats {
+        SDL_threadID id;
+        SDL_mutex *lock;
+        Performance::MetricCollection *metrics;
+    };
+    SDL_mutex *performance_list_lock;
+    std::vector<PerformanceStats> perf_states;
 #endif
 };
 

--- a/src/game.h
+++ b/src/game.h
@@ -58,6 +58,7 @@ struct GameState {
 #ifdef PERFORMANCE_ENABLE
     struct PerformanceStats {
         SDL_threadID id;
+        const char *name;
         SDL_mutex *lock;
         Performance::MetricCollection *metrics;
     };

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -338,6 +338,10 @@ int main(int argc, char **argv) { // Game entrypoint
     game_state.imgui.network_port = network_port;
 #endif
 
+#ifdef PERFORMANCE_ENABLE
+    game_state.performance_list_lock = SDL_CreateMutex();
+#endif
+
     game_lib.init(&game_state, width, height);
     platform_audio_init();
     game_state.audio_struct = &platform_audio_struct;

--- a/src/util/defer.h
+++ b/src/util/defer.h
@@ -28,3 +28,6 @@ Defer<F> operator<<(defer_dummy, F &&f) {
 }
 
 #define defer auto _defer(__LINE__) = defer_dummy() << [&]()
+
+// This macro exists for places where you cannot explicitly capture everything.
+#define defer_expl auto _defer(__LINE__) = defer_dummy() <<

--- a/src/util/performance.cpp
+++ b/src/util/performance.cpp
@@ -21,6 +21,7 @@ static void register_thread_for_performance_counting() {
     metrics_thread_lock = SDL_CreateMutex();
     GAMESTATE()->perf_states.push_back({
         SDL_ThreadID(),
+        SDL_GetThreadName(nullptr), // TODO(ed): This isn't working, no name is given.
         metrics_thread_lock,
         &metrics,
     });

--- a/src/util/performance.cpp
+++ b/src/util/performance.cpp
@@ -258,19 +258,7 @@ void report() {
     ImGui::End();
 }
 #else // Without IMGUI
-void report() {
-    LOCK();
-    for (auto &[hash, counter] : metrics) {
-        LOG("{} - #{} {}ns {}ns/call",
-            counter.name,
-            counter.num_calls,
-            counter.total_nano_seconds,
-            counter.total_nano_seconds / (counter.num_calls ?: 1));
-        counter.num_calls = 0;
-        counter.total_nano_seconds = 0;
-    }
-    UNLOCK();
-}
+void report() {}
 #endif
 
 #else

--- a/src/util/performance.h
+++ b/src/util/performance.h
@@ -2,6 +2,7 @@
 #include "../math/types.h"
 #include "../math/smek_math.h"
 #include <chrono>
+#include <unordered_map>
 
 namespace Performance {
 
@@ -9,7 +10,7 @@ constexpr u32 HISTORY_LENGTH = 1001;
 
 using Clock = std::chrono::steady_clock;
 using TimePoint = std::chrono::time_point<Clock>;
-struct PerformanceCounter {
+struct Metric {
     const char *name;
 
     const char *function;
@@ -24,6 +25,7 @@ struct PerformanceCounter {
 
     TimePoint start;
 };
+using MetricCollection = std::unordered_map<u64, Metric>;
 
 u64 begin_time_block(const char *name,
                      u64 hash_uuid,


### PR DESCRIPTION
Restructure the performance counting code to be threadsafe,
and thus allow PERFORMANCE macros in other threads.

Haven't tested if it works when threads die, since it's in the middle of the night.
