### PR TITLE
Fix bug in sntprint

### DIFF
--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -156,3 +156,24 @@ TEST_CASE("reuse sntprint buffer - with formatting over buf_size", {
     ASSERT(std::strcmp(buffer, "3") == 0, "Got '{}', '3' expected", buffer);
     return true;
 });
+
+TEST_CASE("sntprint - extra {}", {
+    char buffer[4] = {};
+    sntprint(buffer, LEN(buffer), "{}{}", 1);
+    ASSERT(std::strcmp(buffer, "1") == 0, "Got '{}', '1' expected", buffer);
+    return true;
+});
+
+TEST_CASE("sntprint - extra {}", {
+    char buffer[4] = {};
+    sntprint(buffer, LEN(buffer), "{}{}{}{}{}{}", 2);
+    ASSERT(std::strcmp(buffer, "2") == 0, "Got '{}', '2' expected", buffer);
+    return true;
+});
+
+TEST_CASE("sntprint - just enough", {
+    char buffer[10] = {};
+    sntprint(buffer, LEN(buffer), "{}-{}-{}%{", 3, 2, 1);
+    ASSERT(std::strcmp(buffer, "3-2-1") == 0, "Got '{}', '3-2-1{' expected", buffer);
+    return true;
+});

--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -155,52 +155,26 @@ TEST_CASE("reuse sntprint buffer - with formatting over buf_size", {
     return true;
 });
 
-TEST_CASE("sntprint - extra {}", {
-    char buffer[4] = {};
-    sntprint(buffer, LEN(buffer), "{}{}", 1);
-    ASSERT(std::strcmp(buffer, "1{}") == 0, "Got '{}', '1{}' expected", buffer);
-    return true;
-});
+#define SNTPRINT_TEST(name, buflen, exp, fmt, ...)                                       \
+    TEST_CASE("sntprint - " name, {                                                      \
+        char buf[buflen] = {};                                                           \
+        const char *fmt_str = fmt;                                                       \
+        const char *exp_str = exp;                                                       \
+        sntprint(buf, buflen, fmt_str, __VA_ARGS__);                                     \
+        ASSERT(std::strcmp(buf, exp_str) == 0, "Got '{}', '{}' expected", buf, exp_str); \
+        return true;                                                                     \
+    })
 
-TEST_CASE("sntprint - extra {}", {
-    char buffer[4] = {};
-    sntprint(buffer, LEN(buffer), "{}{}{}{}{}{}", 2);
-    ASSERT(std::strcmp(buffer, "2{}") == 0, "Got '{}', '2' expected", buffer);
-    return true;
-});
+SNTPRINT_TEST("extra fmt #1", 4, "1{}", "{}{}", 1);
 
-TEST_CASE("sntprint - just enough", {
-    char buffer[15] = {};
-    sntprint(buffer, LEN(buffer), "{}-!{}{}-{}!{}", 3, 2, 1);
-    LOG("{}", buffer);
-    bool success = std::strcmp(buffer, "3-{}2-1{}") == 0;
-    ASSERT(success, "Invalid test result");
-    return true;
-});
+SNTPRINT_TEST("extra fmt #2", 4, "2{}", "{}{}{}{}{}{}", 2);
 
-TEST_CASE("sntprint - random !", {
-    char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "{}!-!{}{}-{}!", 3, 2, 1);
-    LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "3!-{}2-1!") == 0;
-    ASSERT(success, "Invalid test result");
-    return true;
-});
+SNTPRINT_TEST("escape fmt #1", 15, "3-{}2-1{}", "{}-!{}{}-{}!{}", 3, 2, 1);
 
-TEST_CASE("sntprint - random !", {
-    char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "!{}{}!", 1);
-    LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "{}1!") == 0;
-    ASSERT(success, "Invalid test result");
-    return true;
-});
+SNTPRINT_TEST("escape fmt #2", 15, "3!-{}2-1!", "{}!-!{}{}-{}!", 3, 2, 1);
 
-TEST_CASE("sntprint - even more random !", {
-    char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "!{}{}!-{}!", 1, 2);
-    LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "{}1!-2!") == 0;
-    ASSERT(success, "Invalid test result");
-    return true;
-});
+SNTPRINT_TEST("escape fmt #3", 15, "{}1!", "!{}{}!", 1);
+
+SNTPRINT_TEST("escape fmt #4", 15, "!{}! 1!!", "!!{}! {}!!", 1);
+
+SNTPRINT_TEST("escape fmt #5", 15, "{}1!-2!", "!{}{}!-{}!", 1, 2);

--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -48,17 +48,25 @@ u32 smek_snprint(char *out_buffer, u32 buf_size, const char *in_buffer) {
 template <>
 i32 sntprint<>(char *buffer, u32 buf_size, const char *fmt) {
     if (buf_size == 0) return 0;
+    u32 write = 0;
     u32 head = 0;
-    while (fmt[head] && head != buf_size) {
-        buffer[head] = fmt[head];
-        head++;
+    for (; fmt[head] && head != buf_size; head++) {
+        if (fmt[head] == '%') {
+            if (fmt[head + 1] == '{') { continue; }
+        } else if (fmt[head] == '{') {
+            WARN("Invalid format string, unexpected '{}'", fmt + head);
+            buffer[write] = '\0';
+            return write;
+        } else {
+            buffer[write++] = fmt[head];
+        }
     }
     if (head == buf_size) {
-        buffer[head - 1] = '\0';
+        buffer[write - 1] = '\0';
     } else {
-        buffer[head] = '\0';
+        buffer[write] = '\0';
     }
-    return head;
+    return write;
 }
 
 #include "../test.h"

--- a/src/util/tprint.cpp
+++ b/src/util/tprint.cpp
@@ -54,7 +54,7 @@ i32 sntprint<>(char *buffer, u32 buf_size, const char *fmt) {
         if (fmt[head] == '{') {
             WARN("Invalid format string, unexpected '{}'", fmt + head);
         }
-        if (fmt[head] == '%' && fmt[head + 1] == '{') {
+        if (fmt[head] == '!' && fmt[head + 1] == '{') {
             head++;
         }
         buffer[write++] = fmt[head];
@@ -165,42 +165,42 @@ TEST_CASE("sntprint - extra {}", {
 TEST_CASE("sntprint - extra {}", {
     char buffer[4] = {};
     sntprint(buffer, LEN(buffer), "{}{}{}{}{}{}", 2);
-    ASSERT(std::strcmp(buffer, "2") == 0, "Got '{}', '2' expected", buffer);
+    ASSERT(std::strcmp(buffer, "2{}") == 0, "Got '{}', '2' expected", buffer);
     return true;
 });
 
 TEST_CASE("sntprint - just enough", {
     char buffer[15] = {};
-    sntprint(buffer, LEN(buffer), "{}-%{}{}-{}%{}", 3, 2, 1);
+    sntprint(buffer, LEN(buffer), "{}-!{}{}-{}!{}", 3, 2, 1);
     LOG("{}", buffer);
     bool success = std::strcmp(buffer, "3-{}2-1{}") == 0;
     ASSERT(success, "Invalid test result");
     return true;
 });
 
-TEST_CASE("sntprint - random %", {
+TEST_CASE("sntprint - random !", {
     char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "{}%-%{}{}-{}%", 3, 2, 1);
+    int ret = sntprint(buffer, LEN(buffer), "{}!-!{}{}-{}!", 3, 2, 1);
     LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "3%-{}2-1%") == 0;
+    bool success = std::strcmp(buffer, "3!-{}2-1!") == 0;
     ASSERT(success, "Invalid test result");
     return true;
 });
 
-TEST_CASE("sntprint - random %", {
+TEST_CASE("sntprint - random !", {
     char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "%{}{}%", 1);
+    int ret = sntprint(buffer, LEN(buffer), "!{}{}!", 1);
     LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "{}1%") == 0;
+    bool success = std::strcmp(buffer, "{}1!") == 0;
     ASSERT(success, "Invalid test result");
     return true;
 });
 
-TEST_CASE("sntprint - even more random %", {
+TEST_CASE("sntprint - even more random !", {
     char buffer[15] = {};
-    int ret = sntprint(buffer, LEN(buffer), "%{}{}%-{}%", 1, 2);
+    int ret = sntprint(buffer, LEN(buffer), "!{}{}!-{}!", 1, 2);
     LOG("{} -> {}", buffer, ret);
-    bool success = std::strcmp(buffer, "{}1%-2") == 0;
+    bool success = std::strcmp(buffer, "{}1!-2!") == 0;
     ASSERT(success, "Invalid test result");
     return true;
 });

--- a/src/util/tprint.h
+++ b/src/util/tprint.h
@@ -88,7 +88,7 @@ i32 sntprint_helper(char *buffer, u32 buf_size, const char *fmt, T first, Args..
 #define SKIP fmt++
 
     while (*fmt) {
-        if (*fmt == '%') {
+        if (*fmt == '!') {
             if (*(fmt + 1) == '{') { SKIP; }
             EAT;
         } else if (*fmt == '{') {


### PR DESCRIPTION
sntprint would print "{}" if it was after the number of arguments. Now it
warns. Tests have also been added.
