### PR TITLE
Logging levels

### DIFF
--- a/sconstruct.py
+++ b/sconstruct.py
@@ -314,7 +314,7 @@ def create_smek_target():
         libsmek = jumbo_env.SharedLibrary(smek_dir + smek_game_lib, [smek_dir + "game.cpp"])
 
         plt_env = env.Clone()
-        plt_env.Append(CXXFLAGS=["-include", "src/util/tprint.cpp"])
+        plt_env.Append(CXXFLAGS=["-include", "src/util/tprint.cpp", "-include", "src/util/log.cpp"]) #TODO(gu) list comprehension and *-operator
         platform_source = plt_env.Object(smek_dir + "platform.cpp")
         smek = env.Program(smek_dir + "SMEK", [platform_source, glad, imgui])
     else:
@@ -323,7 +323,7 @@ def create_smek_target():
         smek_source.remove(smek_dir + "platform.cpp")
         libsmek = env.SharedLibrary(smek_dir + smek_game_lib, [*smek_source])
 
-        platform_source = [smek_dir + "platform.cpp", smek_dir + "util/tprint.cpp"]
+        platform_source = [smek_dir + "platform.cpp", smek_dir + "util/tprint.cpp", smek_dir + "util/log.cpp"]
         smek = env.Program(smek_dir + "SMEK", [*platform_source, glad, imgui])
 
     if native and PLATFORMS["linux"]:

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -191,7 +191,7 @@ void Player::update_position() {
         }
     }
     if (last_input.shot) {
-        LOG("Pew!");
+        INFO("Pew!");
     }
     position += velocity * delta();
 }
@@ -405,7 +405,7 @@ void EntitySystem::send_state(ClientHandle *handle) {
 }
 
 void EntitySystem::send_initial_state(ClientHandle *handle) {
-    LOG("Sending initial state to client");
+    TRACE("Sending initial state to client");
     Package entity_package;
     entity_package.header.type = PackageType::EVENT;
     for (const auto &[_, entity] : entities) {
@@ -430,7 +430,7 @@ void EntitySystem::send_initial_state(ClientHandle *handle) {
 void EntitySystem::drop_client(u64 client_id) {
     for (const auto &[id, entity] : entities) {
         if ((id & CLIENT_MASK) == client_id) {
-            LOG("Dropping entity with id {}", id);
+            TRACE("Dropping entity with id {}", id);
             entity->remove = true;
         }
     }

--- a/src/entity/entity.h
+++ b/src/entity/entity.h
@@ -173,7 +173,7 @@ E *EntitySystem::fetch(EntityID id) {
 template <typename E>
 EntityID EntitySystem::add_with_id(E entity, EntityID id) {
     ASSERT(!is_valid(id), "Adding multiple entities for id {}", id);
-    LOG("Adding with id {}", id);
+    TRACE("Adding with id {}", id);
     E *e = new E();
     *e = entity;
     e->type = type_of(e);

--- a/src/entity/entity_editor.cpp
+++ b/src/entity/entity_editor.cpp
@@ -117,7 +117,7 @@ void EntitySystem::draw_imgui() {
                         int status;
                         char *demangled = abi::__cxa_demangle(name, 0, 0, &status);
                         ASSERT_EQ(status, 0);
-                        LOG("Failed to 'ImGui show' field '{}' with unsupported type '{}'", f.name, demangled);
+                        TRACE("Failed to 'ImGui show' field '{}' with unsupported type '{}'", f.name, demangled);
                         func_map[hash] = ImGuiFuncs::empty_f;
                         delete[] demangled;
                     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -55,7 +55,7 @@ void toggle_full_screen() {
 }
 
 void something() {
-    LOG("SOMETHIGN!");
+    INFO("SOMETHIGN!");
 }
 
 void init_game(GameState *gamestate, int width, int height) {

--- a/src/game.h
+++ b/src/game.h
@@ -51,7 +51,7 @@ struct GameState {
     bool resized_window;
     bool full_screen_window;
     bool allow_user_resize_window;
-    LogLevel lowest_log =  LogLevel::INFO;
+    u32 log_levels = LogLevel::ALL;
 
 #ifdef IMGUI_ENABLE
     ImGuiState imgui = {};

--- a/src/game.h
+++ b/src/game.h
@@ -9,6 +9,7 @@
 #include "entity/entity.h"
 #include "network/network.h"
 #include "util/performance.h"
+#include "util/log.h"
 
 #include <queue>
 
@@ -50,6 +51,7 @@ struct GameState {
     bool resized_window;
     bool full_screen_window;
     bool allow_user_resize_window;
+    LogLevel lowest_log =  LogLevel::INFO;
 
 #ifdef IMGUI_ENABLE
     ImGuiState imgui = {};

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -44,6 +44,10 @@ struct GameLibrary {
 GameState game_state = {};
 Audio::AudioStruct platform_audio_struct = {};
 
+GameState *GAMESTATE() {
+    return &game_state;
+}
+
 SDL_mutex *m_reload_lib;
 bool hot_reload_active = true;
 bool reload_lib = false;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -245,7 +245,6 @@ bool update_to_default_window_size(int *width, int *height, f32 screen_percent) 
     return false;
 }
 
-#include "util/log.cpp"           // I know, just meh.
 int main(int argc, char **argv) { // Game entrypoint
     int width = 500;
     int height = 500;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -360,7 +360,7 @@ int main(int argc, char **argv) { // Game entrypoint
     u32 next_update = SDL_GetTicks() - MS_PER_FRAME;
     while (game_state.running) {
         if (load_gamelib()) {
-            LOG("PLATFORM LAYER RELOAD!");
+            INFO("Platform layer reload");
             game_lib.reload(&game_state);
         }
 

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -44,9 +44,11 @@ struct GameLibrary {
 GameState game_state = {};
 Audio::AudioStruct platform_audio_struct = {};
 
+#ifndef TESTS
 GameState *GAMESTATE() {
     return &game_state;
 }
+#endif
 
 SDL_mutex *m_reload_lib;
 bool hot_reload_active = true;

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -52,7 +52,7 @@
 
 //// Macros
 // All output can be colored with different color-macros.
-LOG(RED "R" GREEN "G" BLUE "B" RESET);
+INFO(RED "R" GREEN "G" BLUE "B" RESET);
 // Make sure to always reset to normal output.
 
 //// CLEAR

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -1,4 +1,11 @@
 #include "log.h"
+#include "../game.h"
+
+void _smek_log(const char *buffer, u32 log_level) {
+    if (GAMESTATE()->log_levels & log_level) {
+        smek_print(buffer);
+    }
+}
 
 #ifdef WINDOWS
 void print_stacktrace(unsigned int max_frames) {

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -3,11 +3,31 @@
 #include "../math/types.h"
 #include "color.h"
 
-// https://stackoverflow.com/a/5891370/4904628, info on ##__VA_ARGS__
-#define ERR(...)              _smek_log_err(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
-#define WARN(...)             _smek_log_warn(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
-#define LOG(...)              _smek_log_info(__FILE__, __LINE__, __func__, ##__VA_ARGS__)
-#define UNREACHABLE(msg, ...) _smek_unreachable(__FILE__, __LINE__, __func__, msg, ##__VA_ARGS__)
+enum class LogLevel {
+    TRACE,
+    INFO,
+    WARNING,
+    ERROR,
+    NOTHING,
+};
+
+#define _LOGLEVEL(LEVEL, FUNC, ...)                             \
+    do {                                                        \
+        if (GAMESTATE()->lowest_log <= (LEVEL))                 \
+            FUNC(__FILE__, __LINE__, __func__, __VA_ARGS__);   \
+    } while (0)
+
+#define ERR(...)   _LOGLEVEL(LogLevel::ERROR, _smek_log_err, __VA_ARGS__)
+#define WARN(...)  _LOGLEVEL(LogLevel::WARNING, _smek_log_warn, __VA_ARGS__)
+#define INFO(...)  _LOGLEVEL(LogLevel::INFO, _smek_log_info, __VA_ARGS__)
+#define TRACE(...) _LOGLEVEL(LogLevel::TRACE, _smek_log_trace, __VA_ARGS__)
+
+#define ERR_ALWAYS(...)   _smek_log_err(__FILE__, __LINE__, __func__, __VA_ARGS__)
+#define WARN_ALWAYS(...)  _smek_log_warn(__FILE__, __LINE__, __func__, __VA_ARGS__)
+#define INFO_ALWAYS(...)  _smek_log_info(__FILE__, __LINE__, __func__, __VA_ARGS__)
+#define TRACE_ALWAYS(...) _smek_log_trace(__FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#define UNREACHABLE(...) _smek_unreachable(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #define STR(x) #x
 
@@ -66,6 +86,9 @@ template <typename... Args>
 void _smek_log_info(const char *file, u32 line, const char *func, const char *message, Args... args);
 
 template <typename... Args>
+void _smek_log_trace(const char *file, u32 line, const char *func, const char *message, Args... args);
+
+template <typename... Args>
 void _smek_unreachable(const char *file, u32 line, const char *func, const char *message, Args... args);
 
 template <typename... Args>
@@ -106,6 +129,16 @@ void _smek_log_info(const char *file, u32 line, const char *func, const char *me
     char buffer[LOG_BUFFER_SIZE] = {};
     u32 len = 0;
     len += sntprint(buffer, LOG_BUFFER_SIZE, WHITE "I {}" RESET " @ {} ({}): ", file, line, func);
+    len += sntprint(buffer + len, LOG_BUFFER_SIZE - len, message, args...);
+    len += sntprint(buffer + len, LOG_BUFFER_SIZE - len, "\n");
+    smek_print(buffer);
+}
+
+template <typename... Args>
+void _smek_log_trace(const char *file, u32 line, const char *func, const char *message, Args... args) {
+    char buffer[LOG_BUFFER_SIZE] = {};
+    u32 len = 0;
+    len += sntprint(buffer, LOG_BUFFER_SIZE, "D {} @ {} ({}): ", file, line, func);
     len += sntprint(buffer + len, LOG_BUFFER_SIZE - len, message, args...);
     len += sntprint(buffer + len, LOG_BUFFER_SIZE - len, "\n");
     smek_print(buffer);
@@ -164,7 +197,10 @@ bool _smek_check(const char *file, u32 line, const char *func, bool passed, cons
 // least a string to be printed. The output is always on stderr.
 
 ///*
-LOG(...)
+TRACE(...)
+
+///*
+INFO(...)
 
 ///*
 WARN(...)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -3,18 +3,19 @@
 #include "../math/types.h"
 #include "color.h"
 
-enum class LogLevel {
-    TRACE,
-    INFO,
-    WARNING,
-    ERROR,
-    NOTHING,
-};
+namespace LogLevel {
+static const u32 NONE    = 0;
+static const u32 TRACE   = 1 << 0;
+static const u32 INFO    = 1 << 1;
+static const u32 WARNING = 1 << 2;
+static const u32 ERROR   = 1 << 3;
+static const u32 ALL     =(1 << 4) - 1; // update this if changing log levels
+}
 
 #define _LOGLEVEL(LEVEL, FUNC, ...)                             \
     do {                                                        \
-        if (GAMESTATE()->lowest_log <= (LEVEL))                 \
-            FUNC(__FILE__, __LINE__, __func__, __VA_ARGS__);   \
+        if (GAMESTATE()->log_levels & (LEVEL))                  \
+            FUNC(__FILE__, __LINE__, __func__, __VA_ARGS__);    \
     } while (0)
 
 #define ERR(...)   _LOGLEVEL(LogLevel::ERROR, _smek_log_err, __VA_ARGS__)

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -31,8 +31,8 @@ enum class LogLevel {
 
 #define STR(x) #x
 
-#define ASSERT(pass, msg, ...) _smek_assert(__FILE__, __LINE__, __func__, pass, STR(pass), msg, ##__VA_ARGS__)
-#define CHECK(pass, msg, ...)  _smek_check(__FILE__, __LINE__, __func__, pass, STR(pass), msg, ##__VA_ARGS__)
+#define ASSERT(pass, ...) _smek_assert(__FILE__, __LINE__, __func__, pass, STR(pass), __VA_ARGS__)
+#define CHECK(pass, ...)  _smek_check(__FILE__, __LINE__, __func__, pass, STR(pass), __VA_ARGS__)
 
 #define ASSERT_EQ(LHS, RHS)                                                                           \
     do {                                                                                              \

--- a/src/util/performance.cpp
+++ b/src/util/performance.cpp
@@ -158,7 +158,7 @@ void capture_handle() {
             Capture::frames_to_capture--;
 
         if (Capture::frames_to_capture == 0) {
-            LOG("End of performance capture.");
+            TRACE("End of performance capture.");
             LOCK_FOR_BLOCK(capture_file_mutex);
             const char postamble[] = "]";
             fwrite((void *)postamble, 1, LEN(postamble) - 1, capture_file);


### PR DESCRIPTION
I called the new level trace since debug is used as a compilation-flag.

We can't ask the gamestate for the current level set when the gamestate isn't reachable. An idea is to let the platform layer handle the printing instead.

- [x] Specifying a combination of log modes to print out. 